### PR TITLE
Update build environment

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,10 +22,10 @@ install:
   - ps: choco install -y --no-progress --allow-empty-checksums -r sqlite --version 3.19.2
   - ps: choco install -y --no-progress --allow-empty-checksums -r pkgconfiglite # TODO can we get rid of this dependency?
   
-  - ps: Start-FileDownload 'https://github.com/pairinteraction/pairinteraction-build-dependencies/releases/download/1528914514/cpp-libraries-windows-x86_64.zip'
+  - ps: Start-FileDownload 'https://github.com/pairinteraction/pairinteraction-build-dependencies/releases/download/1572947154/cpp-libraries-windows-x86_64.zip'
   - cmd: 7z x -y cpp-libraries-windows-x86_64.zip > nul
 
-  - ps: Start-FileDownload 'https://github.com/pairinteraction/pairinteraction-build-dependencies/releases/download/1528914514/python-packages-windows-x86_64.zip'
+  - ps: Start-FileDownload 'https://github.com/pairinteraction/pairinteraction-build-dependencies/releases/download/1572947154/python-packages-windows-x86_64.zip'
   - cmd: 7z x -y python-packages-windows-x86_64.zip > nul
   - cmd: conda config --prepend channels file:///%APPVEYOR_BUILD_FOLDER%/conda-export
   - cmd: conda install -y -q pip twine pairinteraction-dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       env:
         - image=debian
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode9.4
       env:
         - package=pairinteraction-install-osx.dmg
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,10 @@ matrix:
         - conda install -y -q nomkl pairinteraction-dependencies
         - conda update -y -q setuptools wheel
         - pip install twine git+https://github.com/pyinstaller/pyinstaller.git@5b6288b4e6c594dd695a2bd5db67aa260b771ce5 # TODO if new version that supports python 3.6 without bugs in conda-forge, specify version of pyinstaller and include pyinstaller in conda-export
-        - brew install gsl llvm@8 swig
+        - brew install gsl swig libomp
         - npm install -g fileicon
       before_script:
-        - export CXX=/usr/local/opt/llvm@8/bin/clang++
-        - export LDFLAGS="-L/usr/local/opt/llvm@8/lib -Wl,-rpath,/usr/local/opt/llvm@8/lib,-rpath,${CONDA_PREFIX}/lib"
+        - export LDFLAGS="-Wl,-rpath,${CONDA_PREFIX}/lib"
     - os: linux
       sudo: required
       services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-4.3.11-MacOSX-x86_64.sh -O miniconda.sh
         - chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda3 && source $HOME/miniconda3/bin/activate root
-        - wget https://github.com/pairinteraction/pairinteraction-build-dependencies/releases/download/1500989872/python-packages-osx.zip
+        - wget https://github.com/pairinteraction/pairinteraction-build-dependencies/releases/download/1572947154/python-packages-osx.zip
         - unzip python-packages-osx.zip
         - conda config --prepend channels file:///$TRAVIS_BUILD_DIR/conda-export
         - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
           packages:
             - python3-pip pyqt5-dev-tools
       install:
-        - python3 -m pip install --user --upgrade setuptools twine
+        - python3 -m pip install --user --upgrade setuptools 'twine<=1.13' # TODO if newest version of twine is working, install it
       env:
         - image=manylinux
     - os: linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with the pairinteraction library. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
 project(pairinteraction CXX)
 set(CMAKE_CXX_STANDARD 14)

--- a/cmake/FindOpenMPCXX.cmake
+++ b/cmake/FindOpenMPCXX.cmake
@@ -1,0 +1,52 @@
+# Copyright (c) 2019 Sebastian Weber, Henri Menke. All rights reserved.
+#
+# This file is part of the pairinteraction library.
+#
+# The pairinteraction library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# The pairinteraction library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with the pairinteraction library. If not, see <http://www.gnu.org/licenses/>.
+
+# Find OpenMP for CXX
+#
+# OpenMP_CXX_LIBRARY           - the openmp library
+# OpenMP_CXX_INCLUDE_DIR       - path including omp.h
+# OpenMP::OpenMP_CXX           - target for using OpenMP
+
+include(FindPackageHandleStandardArgs)
+
+find_package(OpenMP QUIET)
+
+if(NOT OpenMP_FOUND AND APPLE)
+  find_library(OpenMP_CXX_LIBRARY NAMES omp)
+  find_path(OpenMP_CXX_INCLUDE_DIR NAMES omp.h)
+  
+  if (OpenMP_CXX_LIBRARY AND OpenMP_CXX_INCLUDE_DIR)
+    set(OpenMP_CXX_COMPILE_OPTIONS -Xpreprocessor -fopenmp)
+    add_library(OpenMP::OpenMP_CXX SHARED IMPORTED)
+    set_target_properties(OpenMP::OpenMP_CXX PROPERTIES
+      IMPORTED_LOCATION ${OpenMP_CXX_LIBRARY}
+      INTERFACE_INCLUDE_DIRECTORIES "${OpenMP_CXX_INCLUDE_DIR}"
+      INTERFACE_COMPILE_OPTIONS "${OpenMP_CXX_COMPILE_OPTIONS}"
+  )
+  endif()
+  
+  find_package_handle_standard_args(OpenMPCXX DEFAULT_MSG 
+    OpenMP_CXX_LIBRARY OpenMP_CXX_INCLUDE_DIR)
+    
+  mark_as_advanced(OpenMP_CXX_LIBRARY OpenMP_CXX_INCLUDE_DIR)
+  
+else()
+  find_package_handle_standard_args(OpenMPCXX DEFAULT_MSG 
+    OpenMP_FOUND)
+endif()
+
+

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -18,9 +18,9 @@ Packages are available for GNU/Linux, Mac OS X, and Windows through
 :github:`GitHub Releases <releases>`. For these packages, the graphical user interface works out-of-the-box.
 The different packages were built on the following architectures:
 
-- ``deb`` package: Ubuntu 16.04 amd64
-- ``rpm`` package: OpenSUSE Leap x86_64
-- Mac OS X ``dmg``: Mac OS X 10.12
+- ``deb`` package: Ubuntu 18.04 amd64
+- ``rpm`` package: OpenSUSE Leap 15.0 x86_64
+- Mac OS X ``dmg``: Mac OS X 10.13 (Xcode 9.4)
 - Windows ``exe``: Compiled with Visual Studio 2015
 
 Alternatively, you can install pairinteraction from the `Python Package Index`_ via pip by calling ``pip install pairinteraction`` from the command line.
@@ -89,14 +89,14 @@ for compiling the source code.
 Git
     Git is a version control system used to track changes.
 
-CMake 3.2 or later
+CMake 3.9 or later
     The build system is based on CMake.
 
 C++ Backend and Python Interface
 """"""""""""""""""""""""""""""""
 
 C++ Compiler
-    C++11 capable C++ compiler (e.g., GCC 4.8.1 or later).
+    C++14 capable C++ compiler
 
 Sqlite3
    SQLite is a self-contained, high-reliability, embedded,
@@ -178,7 +178,7 @@ These options can be passed directly to ``cmake``, i.e.
 
 This way we can only build the C++ backend with the Python interface.
 
-Ubuntu 16.04
+Ubuntu 18.04
 ^^^^^^^^^^^^
 
 Dependencies
@@ -262,7 +262,7 @@ For the backend we need the following packages
 
 .. code-block:: none
 
-    patterns-openSUSE-devel_C_C++ gcc6-c++ sqlite3 sqlite3-devel boost_1_61-devel gsl-devel swig python3 python3-devel python3-numpy python3-numpy-devel python3-scipy
+    patterns-devel-C-C++-devel_C_C++ sqlite3 sqlite3-devel libboost_filesystem1_66_0-devel libboost_program_options1_66_0-devel libboost_serialization1_66_0-devel libboost_system1_66_0-devel libboost_test1_66_0-devel gsl-devel swig python3 python3-devel python3-numpy python3-numpy-devel python3-scipy
 
 The GUI builds with only ``python3-qt5-devel`` but to run it we
 additionally need
@@ -330,12 +330,7 @@ you have to install (e.g. via homebrew) the following packages
 
 .. code-block:: none
 
-    cmake git gsl swig llvm@3.9
-
-.. note::
-    The package llvm contains the Clang C++ compiler. We use this compiler as it
-    supports OpenMP with OS X. We install version 3.9 because of a bug
-    with the most recent version.
+    cmake git gsl swig libomp
 
 For the Python pairinteraction library and the Python GUI, you need a Python 3
 distribution (we recommend `Miniconda`_ or `Anaconda`_). The following Python 3
@@ -403,7 +398,7 @@ be obtained using
 
 .. code-block:: bash
 
-    sudo apt-get install doxygen graphviz python3-sphinx python3-numpydoc
+    sudo apt-get install doxygen graphviz python3-sphinx python3-numpydoc jupyter-nbconvert pandoc python3-ipykernel python3-matplotlib
 
 Then checkout the latest version of pairinteraction using `git`
 

--- a/pairinteraction/CMakeLists.txt
+++ b/pairinteraction/CMakeLists.txt
@@ -79,10 +79,10 @@ list(APPEND LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
 
 # Use OpenMP
 
-find_package(OpenMP)
+find_package(OpenMPCXX)
 
-if (OPENMP_FOUND AND NOT WITH_CLANG_TIDY)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+if (OpenMPCXX_FOUND AND NOT WITH_CLANG_TIDY)
+  list(APPEND LIBRARIES OpenMP::OpenMP_CXX)
 else()
   message(WARNING "Because OpenMP was not found, calculations are not be parallelized.")
 endif()


### PR DESCRIPTION
* Use OpenMP from libomp so that we do not have to install llvm for mac OS
* Use the newest version of the build dependencies
* Update xcode