### PR TITLE
C++17

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-os: Visual Studio 2015
+os: Visual Studio 2017
 
 platform: x64
 
@@ -8,17 +8,16 @@ environment:
     MINICONDA_ROOT: C:\Miniconda36-x64
     NSIS_ROOT: C:\Program Files (x86)\NSIS
     BOOST_ROOT: C:\Libraries\boost_1_66_0
-    BOOST_LIBRARYDIR: C:\Libraries\boost_1_66_0\lib64-msvc-14.0
+    BOOST_LIBRARYDIR: C:\Libraries\boost_1_66_0\lib64-msvc-14.1
     PATH: "%BOOST_LIBRARYDIR%;%MINICONDA_ROOT%;%MINICONDA_ROOT%\\Scripts;%MINICONDA_ROOT%\\Library\\bin;%PATH%"
     APPVEYOR_SAVE_CACHE_ON_ERROR: true
- 
+
 install:
   - git submodule update --init --recursive
 
-  - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 
-  - ps: choco install -y --no-progress --allow-empty-checksums -r swig --version 3.0.9
+  - ps: choco install -y --no-progress --allow-empty-checksums -r swig --version 4.0.1
   - ps: choco install -y --no-progress --allow-empty-checksums -r sqlite --version 3.19.2
   - ps: choco install -y --no-progress --allow-empty-checksums -r pkgconfiglite # TODO can we get rid of this dependency?
   
@@ -38,16 +37,18 @@ cache:
 
 before_build:
   - cmd: md build && cd build
-  - cmd: cmake -G "Visual Studio 14 2015 Win64" .. -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE -DWITH_DOCS=FALSE -DCMAKE_TOOLCHAIN_FILE=vcpkg-export\scripts\buildsystems\vcpkg.cmake"
+  - cmd: cmake -G "Visual Studio 15 2017 Win64" .. -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE -DWITH_DOCS=FALSE -DCMAKE_TOOLCHAIN_FILE=vcpkg-export\scripts\buildsystems\vcpkg.cmake"
 
 build_script:
   - cmd: cmake --build . --config "%CONFIGURATION%"
   
 after_build:
-  - cmd: copy %BOOST_LIBRARYDIR%\boost_filesystem-vc140-mt-x64-*.dll pairinteraction\Release
-  - cmd: copy %BOOST_LIBRARYDIR%\boost_program_options-vc140-mt-x64-*.dll pairinteraction\Release
-  - cmd: copy %BOOST_LIBRARYDIR%\boost_serialization-vc140-mt-x64-*.dll pairinteraction\Release
-  - cmd: copy %BOOST_LIBRARYDIR%\boost_system-vc140-mt-x64-*.dll pairinteraction\Release
+  - cmd: copy %BOOST_LIBRARYDIR%\boost_filesystem-vc141-mt-x64-*.dll pairinteraction\Release
+  - cmd: copy %BOOST_LIBRARYDIR%\boost_program_options-vc141-mt-x64-*.dll pairinteraction\Release
+  - cmd: copy %BOOST_LIBRARYDIR%\boost_serialization-vc141-mt-x64-*.dll pairinteraction\Release
+  - cmd: copy %BOOST_LIBRARYDIR%\boost_system-vc141-mt-x64-*.dll pairinteraction\Release
+  - cmd: set /p RedistVersion=<"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
+  - cmd: copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\%RedistVersion%\vcredist_x64.exe" vcredist_x64.exe
   - cmd: cmake --build . --target win32 --config "%CONFIGURATION%"
   - cmd: python setup.py bdist_wheel --python-tag py3 --plat-name win_amd64
   - ps: $env:PATH_WHEEL_UNMODIFIED=$(ls dist\*.whl | foreach { $_.FullName })

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       env:
         - image=debian
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode11
       env:
         - package=pairinteraction-install-osx.dmg
       before_install:
@@ -22,6 +22,7 @@ matrix:
         - wget https://github.com/pairinteraction/pairinteraction-build-dependencies/releases/download/1572947154/python-packages-osx.zip
         - unzip python-packages-osx.zip
         - conda config --prepend channels file:///$TRAVIS_BUILD_DIR/conda-export
+        - export HOMEBREW_NO_INSTALL_CLEANUP=1
         - brew update
       install:
         - conda install -y -q nomkl pairinteraction-dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
 project(pairinteraction CXX)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 enable_testing()
 
 set(LIBNAME "pairinteraction")

--- a/win32/pairinteraction.nsi
+++ b/win32/pairinteraction.nsi
@@ -60,7 +60,7 @@ SectionGroup /e "Dependencies"
     Goto next
 
     update:
-      File "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\1033\vcredist_x64.exe"
+      File "${BUILD_DIR}\vcredist_x64.exe"
       ExecWait "$INSTDIR\vcredist_x64.exe"
       Delete "$INSTDIR\vcredist_x64.exe"
 
@@ -70,7 +70,7 @@ SectionGroup /e "Dependencies"
       Goto next
 
       fail:
-        MessageBox MB_OK "Redistributable for Visual Studio 2015 could not be found!"
+        MessageBox MB_OK "Redistributable for Visual Studio 2017 could not be found!"
     next:
   SectionEnd
 SectionGroupEnd

--- a/win32/pairinteraction.nsi
+++ b/win32/pairinteraction.nsi
@@ -52,10 +52,12 @@ SectionGroup /e "Dependencies"
     ReadRegDword $3 HKLM "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Bld"
     IfErrors update 0
 
-    StrCmp $0 "1" 0 update 
-    IntCmp $1 14 0 update 0
-    IntCmp $2 0 0 update 0
-    IntCmp $3 24215 0 update 0
+    !getdllversion "${BUILD_DIR}\vcredist_x64.exe" RedistVer
+
+    StrCmp $0 "1" 0 update
+    IntCmp $1 "${RedistVer1}" 0 update 0
+    IntCmp $2 "${RedistVer2}" 0 update 0
+    IntCmp $3 "${RedistVer3}" 0 update 0
 
     Goto next
 


### PR DESCRIPTION
This PR is a potential requirement for #103, if we wanted to replace some of the Boost components with standard library ones that are available in C++17.

The procedure of upgrading the toolchain was surprisingly straightforward and the required diff isn't too large.  SWIG needed an update because it generated code that the newer MSVC did no longer like.

TODO:
- [x] The file [`win32/pairinteraction.nsi`](https://github.com/hmenke/pairinteraction/blob/cxx17/win32/pairinteraction.nsi) has yet to be adjusted to use the approriate `vcredist_x64.exe` for VS 2017.

The Linux toolchain did not need any update at all and everything just worked out of the box.  For MSVC I updated to VS 2017 (although without checking first whether VS 2015 would do, but [1] suggested that we'd need at least MSVC 19.14 for `<filesystem>` to work).  The situation is a bit more delicate on macOS, because C++17 support became available only very recently and `<filesystem>` is only available since Xcode 11, which on Travis CI means that we have to build for macOS 10.14 Mojave and drop all older clients.

[1] https://en.cppreference.com/w/cpp/compiler_support