### PR TITLE
Remove CodeCov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis Build Status][travis-svg]][travis-link]
 [![AppVeyor Build Status][appveyor-svg]][appveyor-link]
-[![Code Coverage Report][codecov-svg]][codecov-link]
+[![Coverage Report][codecov-svg]][codecov-link]
 [![PyPI Package][pypi-svg]][pypi-link]
 [![arXiv:1612.08053][arXiv-svg]][arXiv-link]
 [![License][license-svg]][gpl-link]
@@ -28,8 +28,8 @@ The GPL v3 also applies to the combined work and all provided binary builds.
 [appveyor-link]: https://ci.appveyor.com/project/pairinteraction/pairinteraction/branch/master
 [pypi-svg]: https://img.shields.io/pypi/v/pairinteraction.svg?color=orange
 [pypi-link]: https://pypi.org/project/pairinteraction/
-[codecov-svg]: https://codecov.io/gh/pairinteraction/pairinteraction/branch/master/graph/badge.svg
-[codecov-link]: https://codecov.io/gh/pairinteraction/pairinteraction
+[codecov-svg]: https://img.shields.io/badge/code-coverage-blue.svg?style=flat
+[codecov-link]: https://pairinteraction.github.io/pairinteraction/coverage/html/index.html
 [arXiv-svg]: https://img.shields.io/badge/arXiv-1612.08053-b31b1b.svg?style=flat
 [arXiv-link]: https://arxiv.org/abs/1612.08053
 [license-svg]: https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat

--- a/ci/build_docker.sh
+++ b/ci/build_docker.sh
@@ -113,7 +113,3 @@ case "${TRAVIS_OS_NAME}" in
         ;;
 
 esac;
-
-if [ "${image}" = "debian" ]; then
-    curl -s https://codecov.io/bash | bash -s - -X gcov
-fi

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -21,6 +21,7 @@ import sys
 sys.path.insert(0, '@CMAKE_BINARY_DIR@/@LIBNAME@')
 
 repo_slug = os.getenv('TRAVIS_REPO_SLUG', "pairinteraction/pairinteraction")
+user, repo = repo_slug.split("/")
 
 if repo_slug == "pairinteraction/pairinteraction":
     pypi_image = "https://img.shields.io/pypi/v/pairinteraction.svg?color=orange"
@@ -182,8 +183,8 @@ rst_epilog = """
 .. |appveyor| image:: https://ci.appveyor.com/api/projects/status/github/{repo_slug}?branch=master&svg=true
               :target: https://ci.appveyor.com/project/{repo_slug}/branch/master
               :alt: AppVeyor Build Status
-.. |codecov| image:: https://codecov.io/gh/{repo_slug}/branch/master/graph/badge.svg
-             :target: https://codecov.io/gh/{repo_slug}
+.. |codecov| image:: https://img.shields.io/badge/code-coverage-blue.svg?style=flat
+             :target: https://{user}.github.io/{repo}/coverage/html/index.html
              :alt: Code Coverage Report
 .. |pypi| image:: {pypi_image}
           :target: {pypi_target}
@@ -194,4 +195,4 @@ rst_epilog = """
 .. |license| image:: images/license-badge.svg
              :target: https://www.gnu.org/licenses/gpl-3.0.html
              :alt: License
-""".format(repo_slug=repo_slug, pypi_image=pypi_image, pypi_target=pypi_target)
+""".format(repo_slug=repo_slug, user=user, repo=repo, pypi_image=pypi_image, pypi_target=pypi_target)


### PR DESCRIPTION
I don't think we are using CodeCov to its full potential and right now it's only causing apparent build failures, when in reality the build passes.  Since we have our own coverage system, I think CodeCov is mostly redundant and can be removed.