### PR TITLE
Remove some Boost dependencies

### DIFF
--- a/pairinteraction/CMakeLists.txt
+++ b/pairinteraction/CMakeLists.txt
@@ -104,7 +104,7 @@ find_package(Sqlite3 REQUIRED)
 include_directories(SYSTEM ${SQLITE3_INCLUDE_DIR})
 list(APPEND LIBRARIES ${SQLITE3_LIBRARY})
 
-find_package(Boost COMPONENTS filesystem system program_options serialization REQUIRED)
+find_package(Boost COMPONENTS filesystem system serialization REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 list(APPEND LIBRARIES ${Boost_LIBRARIES})
 if(MSVC)

--- a/pairinteraction/Cache.h
+++ b/pairinteraction/Cache.h
@@ -21,9 +21,8 @@
 #define CACHE_H
 
 #include <mutex>
+#include <optional>
 #include <unordered_map>
-
-#include <boost/optional.hpp>
 
 /** \brief Generic cache object
  *
@@ -84,13 +83,13 @@ public:
      * \param key Key
      * \returns Optional element
      */
-    boost::optional<Element> restore(Key const &key) {
+    std::optional<Element> restore(Key const &key) {
         std::lock_guard<std::mutex> lock(cache_mutex);
         auto cached_it = cache.find(key);
         if (cached_it != cache.end()) {
             return cached_it->second;
         }
-        return boost::none;
+        return std::nullopt;
     }
 
     /** \brief Clear the cache

--- a/pairinteraction/ConfParser.h
+++ b/pairinteraction/ConfParser.h
@@ -24,8 +24,6 @@
 #include <sstream>
 #include <string>
 
-#include <boost/lexical_cast.hpp>
-
 /** \brief %Configuration storage
  *
  * This class stores the system configuration.  In essence it is a
@@ -48,19 +46,67 @@ private:
 
         template <typename T>
         value &operator<<(T const &rhs) {
-            m_value = boost::lexical_cast<std::string>(rhs);
+            m_value = std::to_string(rhs);
             return *this;
         }
 
-        template <typename T>
-        value &operator>>(T &rhs) {
-            rhs = boost::lexical_cast<T>(m_value);
+        value &operator<<(std::string const &rhs) {
+            m_value = rhs;
             return *this;
         }
 
-        template <typename T>
-        value const &operator>>(T &rhs) const {
-            rhs = boost::lexical_cast<T>(m_value);
+        value &operator<<(char const *rhs) {
+            m_value = std::string{rhs};
+            return *this;
+        }
+
+        value &operator>>(int &rhs) {
+            rhs = std::stoi(m_value);
+            return *this;
+        }
+
+        value &operator>>(size_t &rhs) {
+            rhs = std::stoul(m_value);
+            return *this;
+        }
+
+        value &operator>>(float &rhs) {
+            rhs = std::stof(m_value);
+            return *this;
+        }
+
+        value &operator>>(double &rhs) {
+            rhs = std::stod(m_value);
+            return *this;
+        }
+
+        value &operator>>(std::string &rhs) {
+            rhs = m_value;
+            return *this;
+        }
+
+        value const &operator>>(int &rhs) const {
+            rhs = std::stoi(m_value);
+            return *this;
+        }
+
+        value const &operator>>(size_t &rhs) const {
+            rhs = std::stoul(m_value);
+            return *this;
+        }
+
+        value const &operator>>(float &rhs) const {
+            rhs = std::stof(m_value);
+            return *this;
+        }
+
+        value const &operator>>(double &rhs) const {
+            rhs = std::stod(m_value);
+            return *this;
+        }
+
+        value const &operator>>(std::string &rhs) const {
+            rhs = m_value;
             return *this;
         }
 

--- a/pairinteraction/QuantumDefect.cpp
+++ b/pairinteraction/QuantumDefect.cpp
@@ -80,8 +80,8 @@ void QuantumDefect::setup(sqlite3 *db) {
 
     Key const key{species, n, l, j};
     if (auto oe = cache.restore(key)) {
-        e = oe.get(); // Restore cache
-        return;       // Return early
+        e = oe.value(); // Restore cache
+        return;         // Return early
     }
 
     std::stringstream ss;

--- a/pairinteraction/State.cpp
+++ b/pairinteraction/State.cpp
@@ -30,25 +30,19 @@
 
 namespace {
 
-inline boost::variant<char, int> getMomentumLabel(int l) {
-    switch (l) {
-    case 0:
-        return 'S';
-    case 1:
-        return 'P';
-    case 2:
-        return 'D';
-    case 3:
-        return 'F';
-    case 4:
-        return 'G';
-    case 5:
-        return 'H';
-    case 6:
-        return 'I';
-    default:
-        return l;
+struct getMomentumLabel {
+    int l;
+    getMomentumLabel(int l) : l(l) {}
+};
+
+inline std::ostream &operator<<(std::ostream &os, getMomentumLabel const &l) {
+    static constexpr std::array const letters = {'S', 'P', 'D', 'F', 'G', 'H', 'I'};
+    if (l.l < static_cast<int>(letters.size())) {
+        os << letters[l.l];
+    } else {
+        os << l.l;
     }
+    return os;
 }
 
 } // namespace

--- a/pairinteraction/State.h
+++ b/pairinteraction/State.h
@@ -32,7 +32,6 @@
 
 #include <boost/serialization/array.hpp>
 #include <boost/serialization/string.hpp>
-#include <boost/variant.hpp>
 
 class MatrixElementCache;
 

--- a/pairinteraction/StateOld.cpp
+++ b/pairinteraction/StateOld.cpp
@@ -30,25 +30,19 @@
 
 namespace {
 
-inline boost::variant<char, int> getMomentumLabel(int l) {
-    switch (l) {
-    case 0:
-        return 'S';
-    case 1:
-        return 'P';
-    case 2:
-        return 'D';
-    case 3:
-        return 'F';
-    case 4:
-        return 'G';
-    case 5:
-        return 'H';
-    case 6:
-        return 'I';
-    default:
-        return l;
+struct getMomentumLabel {
+    int l;
+    getMomentumLabel(int l) : l(l) {}
+};
+
+inline std::ostream &operator<<(std::ostream &os, getMomentumLabel const &l) {
+    static constexpr std::array const letters = {'S', 'P', 'D', 'F', 'G', 'H', 'I'};
+    if (l.l < static_cast<int>(letters.size())) {
+        os << letters[l.l];
+    } else {
+        os << l.l;
     }
+    return os;
 }
 
 } // namespace

--- a/pairinteraction/StateOld.h
+++ b/pairinteraction/StateOld.h
@@ -30,7 +30,6 @@
 
 #include <boost/serialization/array.hpp>
 #include <boost/serialization/string.hpp>
-#include <boost/variant.hpp>
 
 /** \brief %Base class for states
  *

--- a/pairinteraction/Wavefunction.cpp
+++ b/pairinteraction/Wavefunction.cpp
@@ -20,7 +20,6 @@
 #include "Wavefunction.h"
 #include "QuantumDefect.h"
 
-#include <boost/core/ignore_unused.hpp>
 #include <cctype>
 #include <cmath>
 #ifdef WITH_GSL
@@ -123,7 +122,9 @@ double HypergeometricU(double a, double b, double z) {
     }
     return gsl_sf_hyperg_U(a, b, z);
 #else
-    boost::ignore_unused(a, b, z);
+    (void)a;
+    (void)b;
+    (void)z;
     throw std::runtime_error("Whittaker functions require the GSL library!");
 #endif
 }

--- a/pairinteraction/unit_test/cache_test.cpp
+++ b/pairinteraction/unit_test/cache_test.cpp
@@ -20,6 +20,8 @@
 #include "Cache.h"
 #define BOOST_TEST_MODULE Configuration parser test
 #include <boost/test/unit_test.hpp>
+
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -29,9 +31,9 @@ BOOST_AUTO_TEST_CASE(cache_test) // NOLINT
 
     BOOST_CHECK_NO_THROW(cache.save("Hello world!", 1));
 
-    boost::optional<int> oe;
+    std::optional<int> oe;
     BOOST_CHECK_NO_THROW(oe = cache.restore("Hello world!"));
-    BOOST_CHECK_EQUAL(oe.get(), 1);
+    BOOST_CHECK_EQUAL(oe.value(), 1);
 
     BOOST_CHECK_NO_THROW(cache.clear());
 }
@@ -60,6 +62,6 @@ BOOST_AUTO_TEST_CASE(parallel_cache_test) // NOLINT
     }
 
     for (std::size_t i = 0; i < 10; ++i) {
-        BOOST_CHECK_EQUAL(cache.restore(i).get(), "Hello from thread " + std::to_string(i));
+        BOOST_CHECK_EQUAL(cache.restore(i).value(), "Hello from thread " + std::to_string(i));
     }
 }

--- a/pairinteraction/unit_test/conf_parser_test.cpp
+++ b/pairinteraction/unit_test/conf_parser_test.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(conf_parser_test) // NOLINT
 
     // Test subscript getter and str() conversion
     BOOST_CHECK_EQUAL(c["first"].str(), "2");
-    BOOST_CHECK_EQUAL(c["second"].str(), "1.2");
+    BOOST_CHECK_EQUAL(c["second"].str(), "1.200000");
     BOOST_CHECK_EQUAL(c["third"].str(), "Hello World!");
     BOOST_CHECK_EQUAL(c["fourth"].str(), "2");
     BOOST_CHECK_EQUAL(c["fifth"].str(), "Hello World!");
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(conf_parser_test) // NOLINT
     // Test const methods
     Configuration const cc(c);
     BOOST_CHECK_EQUAL(cc["first"].str(), "2");
-    BOOST_CHECK_EQUAL(cc["second"].str(), "1.2");
+    BOOST_CHECK_EQUAL(cc["second"].str(), "1.200000");
     BOOST_CHECK_EQUAL(cc["third"].str(), "Hello World!");
     BOOST_CHECK_EQUAL(cc["fourth"].str(), "2");
     BOOST_CHECK_EQUAL(cc["fifth"].str(), "Hello World!");


### PR DESCRIPTION
This removes some of the Boost dependencies which are unnecessary and can be easily replaced by standard library functionality.  This is part of #103.

Bold entries require linkage.
- [x]  1. Boost.Lexical_Cast was removed. I just wrote all necessary overloads by hand.
- [x]  2. Boost.Iterator was removed and the iterator functions written by hand.  The iterator is no longer conforming but I don't think anybody cares.
- [x]  3. Boost.Core was removed.  `boost::ignore` was replaced by `(void)` cast.
- [x]  4. Boost.Optional could be replaced by `<optional>` in C++17
- [x]  5. Boost.Variant could be replaced by `<variant>` in C++17
- [x]  6. **Boost.Program_options** was removed.  Our argument parser is embarrassingly simple anyway.