### PR TITLE
macOS: 10.15 -> 11

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   macos:
-    runs-on: macos-10.15
+    runs-on: macos-11
     env:
       package: pairinteraction-install-osx.dmg
     steps:
@@ -38,20 +38,23 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install boost eigen fmt gsl libomp
+          brew install boost eigen fmt gsl
           npm install -g fileicon
 
+      - name: Configure
+        run: cmake -S . -B build/ -DBUILD_TESTING=On -DWITH_DMG=On -DCPACK_PACKAGE_FILE_NAME="${package}" -DPython3_FIND_FRAMEWORK=LAST
       - name: Build
+        run: cmake --build build/ -- --keep-going
+      - name: Test
+        run: cmake --build build/ --target test -- --keep-going
+      - name: Package
         run: |
-          cmake -S . -B build/ -DBUILD_TESTING=On -DWITH_DMG=On -DCPACK_PACKAGE_FILE_NAME="${package}" -DPython3_FIND_FRAMEWORK=LAST
-          cmake --build build/ -- --keep-going
-          cmake --build build/ --target test -- --keep-going
           cmake --build build/ --target package -- --keep-going
           cmake --build build/ --target license -- --keep-going
 
       - name: Wheel
         run: |
-          python setup.py bdist_wheel --python-tag py3 --plat-name macosx_10_15_x86_64
+          python setup.py bdist_wheel --python-tag py3 --plat-name macosx_11_0_x86_64
           wheel unpack dist/*.whl -d wheelhouse/
           chmod +x wheelhouse/*/pairinteraction/pairinteraction-* wheelhouse/*/*.data/scripts/start_pairinteraction_gui
           cd wheelhouse/*/pairinteraction

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,6 +5,12 @@ on:
   pull_request:
   schedule:
   - cron: '0 0 * * 1' # Every Monday at 00:00
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled'     
+        required: false
+        default: false
 
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
 env:
@@ -53,6 +59,12 @@ jobs:
           cd ../../..
           wheel pack wheelhouse/* -d wheelhouse/
         working-directory: build/
+
+      - name: Run debugging session in tmate
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && always()
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,6 +5,12 @@ on:
   pull_request:
   schedule:
   - cron: '0 0 * * 1' # Every Monday at 00:00
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled'     
+        required: false
+        default: false
 
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
 env:
@@ -70,6 +76,12 @@ jobs:
           Copy-Item pairinteraction\Release\* pairinteraction\unit_test\Release -Recurse -Force -Verbose
           cmake --build . --target RUN_TESTS --config ${{ env.CMAKE_BUILD_TYPE }}
         working-directory: build/
+
+      - name: Run debugging session in tmate
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && always()
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
 
       - uses: actions/upload-artifact@v3
         with:

--- a/apple/standalone.py
+++ b/apple/standalone.py
@@ -78,16 +78,15 @@ def standalone(file):
                         "Error in making {} standalone. For the library {}, there is no suitable rpath in {}!".format(
                             file, libpath_original, rpaths))
 
-            if not os.path.isfile(libpath):
-                raise RuntimeError(
-                    "Error in making {} standalone. Library {} not found!".format(
-                        file, libpath_original))
-
             libpath_abs = os.path.abspath(libpath)
 
             # If no standard library and no installed library, update path to dependency
-            if (not libpath_abs.startswith(
-                    "/System/Library") and not libpath_abs.startswith("/usr/lib")) or "libsqlite" in libpath_abs:
+            if not libpath_abs.startswith("/System/Library") and not libpath_abs.startswith("/usr/lib"):
+
+                if not os.path.isfile(libpath):
+                    raise RuntimeError(
+                        "Error in making {} standalone. Library {} not found!".format(
+                            file, libpath_original))
 
                 # Update paths
                 if libpath_abs not in executables:


### PR DESCRIPTION
In macOS 11 Big Sur `/usr/lib/libsqlite3.dylib` does not exist anymore. It's now a system library that will be resolved by the dynamic loader upon calling `dlopen("/usr/lib/libsqlite3.dylib")`. Essentially that path has become a special name without any actual file backing it.

Therefore checking for the existence of libraries should only be done for non-system dependencies.