### PR TITLE
fixed depreciated numpy types 

### DIFF
--- a/pairinteraction_gui/pairinteraction/app.py
+++ b/pairinteraction_gui/pairinteraction/app.py
@@ -1156,7 +1156,7 @@ class MainWindow(QtWidgets.QMainWindow):
                                 )[0]
                                 relevantBasis = basis[stateidx]
 
-                                statecoeff = np.ones_like(stateidx, dtype=np.float)
+                                statecoeff = np.ones_like(stateidx, dtype=float)
                                 m1 = self.overlapstate[idx][3]
                                 if m1 != -1:
                                     for j in np.unique(relevantBasis[:, 3]):
@@ -1193,7 +1193,7 @@ class MainWindow(QtWidgets.QMainWindow):
                                     )[0]
                                     relevantBasis = basis[stateidx2]
 
-                                    statecoeff2 = np.ones_like(stateidx2, dtype=np.float)
+                                    statecoeff2 = np.ones_like(stateidx2, dtype=float)
                                     m1 = self.overlapstate[idx][7]
                                     if m1 != -1:
                                         for j in np.unique(relevantBasis[:, 3]):
@@ -1256,7 +1256,7 @@ class MainWindow(QtWidgets.QMainWindow):
                                 )[0]
                                 relevantBasis = basis[stateidx]
 
-                                statecoeff = np.ones_like(stateidx, dtype=np.float)
+                                statecoeff = np.ones_like(stateidx, dtype=float)
                                 m1 = self.overlapstate[idx][7]
                                 if m1 != -1:
                                     for j in np.unique(relevantBasis[:, 3]):
@@ -1302,7 +1302,7 @@ class MainWindow(QtWidgets.QMainWindow):
                                 )[0]
                                 relevantBasis = basis[stateidx]
 
-                                statecoeff = np.ones_like(stateidx, dtype=np.float)
+                                statecoeff = np.ones_like(stateidx, dtype=float)
                                 for selector in [0, 4]:
                                     m1 = self.overlapstate[idx][3 + selector]
                                     if m1 != -1:
@@ -1450,11 +1450,11 @@ class MainWindow(QtWidgets.QMainWindow):
                     # determine labels of momenta
                     if idx == 0 or idx == 1:  # TODO !!!
                         self.momentumstrings[idx] = [
-                            f" {i}" for i in np.arange(np.max(self.labelstates[idx][:, 1]) + 1).astype(np.int)
+                            f" {i}" for i in np.arange(np.max(self.labelstates[idx][:, 1]) + 1).astype(int)
                         ]
                     elif idx == 2:
                         self.momentumstrings[idx] = [
-                            f" {i}" for i in np.arange(np.max(self.labelstates[idx][:, [1, 4]]) + 1).astype(np.int)
+                            f" {i}" for i in np.arange(np.max(self.labelstates[idx][:, [1, 4]]) + 1).astype(int)
                         ]
                     self.momentumstrings[idx][:4] = self.momentslabels
 
@@ -1541,7 +1541,7 @@ class MainWindow(QtWidgets.QMainWindow):
                             symmetrycolor = (40, 40, 40)
 
                     # --- determine which basis elements are within the energy range ---
-                    boolarr = np.ones(len(energies), dtype=np.bool)
+                    boolarr = np.ones(len(energies), dtype=bool)
                     boolarr[np.isnan(energies)] = False
                     energies[np.isnan(energies)] = 0
 
@@ -1580,7 +1580,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
                         # store the value of this momentum
                         # -1 means no determinable momentum
-                        momentum = -np.ones(momentum_probabilty.shape[0], dtype=np.int)
+                        momentum = -np.ones(momentum_probabilty.shape[0], dtype=int)
                         momentum[momentum_probabilty.row] = momentum_probabilty.col
 
                     # --- calculate the position (x value) ---
@@ -2041,7 +2041,7 @@ class MainWindow(QtWidgets.QMainWindow):
                                 self.buffer_boolarr[blocknumber][filestep].append(boolarr)
                         elif idx == 2:
                             self.buffer_boolarr[blocknumber][filestep].append(
-                                np.ones_like(self.buffer_energies[blocknumber][filestep], dtype=np.bool)
+                                np.ones_like(self.buffer_energies[blocknumber][filestep], dtype=bool)
                             )
 
                         # get size and alpha value of points
@@ -3247,7 +3247,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if self.ui.radiobutton_system_quantizationZ.isChecked() and self.angle != 0:
 
                 # find relevant states
-                statesum = np.zeros(data["numStates"], dtype=np.float)
+                statesum = np.zeros(data["numStates"], dtype=float)
                 for s in range(data["numSteps"]):
                     statesum += np.abs(data["eigenvectors"][s]).sum(axis=1).getA1()
                 statesum += np.abs(data["overlapvectors"]).sum(axis=0).getA1()

--- a/pairinteraction_gui/pairinteraction/pyqtgraphadditions.py
+++ b/pairinteraction_gui/pairinteraction/pyqtgraphadditions.py
@@ -42,8 +42,8 @@ class PointsItem(pg.Qt.QtWidgets.QGraphicsItem):
         # see http://stackoverflow.com/questions/20119777
         self.qpoints = pg.QtGui.QPolygonF(npoints)
         vptr = self.qpoints.data()
-        vptr.setsize(np.dtype(np.float).itemsize * 2 * npoints)
-        data = np.ndarray(shape=(npoints, 2), dtype=np.float, buffer=memoryview(vptr))
+        vptr.setsize(np.dtype(float).itemsize * 2 * npoints)
+        data = np.ndarray(shape=(npoints, 2), dtype=float, buffer=memoryview(vptr))
         data.setflags(write=True)
         data[:, 0] = x
         data[:, 1] = y

--- a/testsuite/parallelization.py
+++ b/testsuite/parallelization.py
@@ -82,8 +82,8 @@ class TestPythoninterfaceMultiprocessing(unittest.TestCase):
                 line_mapper[iFirst] = tmp
 
                 # Store line segments
-                line_idx += line_mapper[iFirst].astype(np.int).tolist()
-                line_step += (i * np.ones(len(iFirst), dtype=np.int)).tolist()
+                line_idx += line_mapper[iFirst].astype(int).tolist()
+                line_step += (i * np.ones(len(iFirst), dtype=int)).tolist()
                 line_val += stark_shifted_systems[i].getHamiltonian().diagonal()[iSecond].tolist()
 
                 # Assign the line indices to iSecond, delete line indices that could not be assigned
@@ -156,8 +156,8 @@ class TestPythoninterfaceMultiprocessing(unittest.TestCase):
                 line_mapper[iFirst] = tmp
 
                 # Store line segments
-                line_idx += line_mapper[iFirst].astype(np.int).tolist()
-                line_step += (i * np.ones(len(iFirst), dtype=np.int)).tolist()
+                line_idx += line_mapper[iFirst].astype(int).tolist()
+                line_step += (i * np.ones(len(iFirst), dtype=int)).tolist()
                 line_val += dipole_interacting_systems[i].getHamiltonian().diagonal()[iSecond].tolist()
 
                 # Assign the line indices to iSecond, delete line indices that could not be assigned


### PR DESCRIPTION
I replaced all np.bool, np.int, np.float with bool, int, float respectively, as former are depreciated in numpy 
 1.20.0. The numpy types were just aliases for the builtin types according to: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations