### PR TITLE
Build with scikit-build-core

### DIFF
--- a/.github/workflows/skbuild.yml
+++ b/.github/workflows/skbuild.yml
@@ -1,0 +1,81 @@
+name: skbuild
+
+on:
+  push:
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 2
+  CTEST_PARALLEL_LEVEL: 2
+  CTEST_OUTPUT_ON_FAILURE: 1
+  VERBOSE: 1
+
+jobs:
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+
+    - name: Build SDist
+      run: pipx run build --sdist
+
+    - name: Check metadata
+      run: pipx run twine check dist/*
+
+    - uses: actions/upload-artifact@v3
+      with:
+        path: dist/*.tar.gz
+
+  wheel:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: ubuntu-latest # runs in container anyway
+          CXXFLAGS: "-Wall -Wextra -Wpedantic -march=broadwell"
+          CMAKE_ARGS: "-DBUILD_TESTING=Off"
+        - os: macos-12
+          CXXFLAGS: "-Wall -Wextra -Wpedantic"
+          CMAKE_ARGS: "-DBUILD_TESTING=Off"
+        - os: windows-2019
+          CXXFLAGS: "/Ox /arch:AVX2"
+          CMAKE_ARGS: "-DBUILD_TESTING=Off -DMKL_THREADING=intel_thread"
+    name: Wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+
+    - name: Install Intel oneAPI Math Kernel Library (oneMKL)
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/install-intel-mkl
+
+    - name: Install Windows dependencies
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/setup-vcpkg
+
+    - name: Install macOS dependencies
+      if: runner.os == 'macOS'
+      run: brew install boost cereal doctest eigen fmt gsl lapack
+
+    - uses: pypa/cibuildwheel@v2.16
+      env:
+        CMAKE_ARGS: ${{ matrix.CMAKE_ARGS }}
+        CXXFLAGS: ${{ matrix.CXXFLAGS }}
+        CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/pairinteraction/pairinteraction-manylinux:docker
+        CIBW_ENVIRONMENT_LINUX: CMAKE_ARGS='${{ matrix.CMAKE_ARGS }}' CXXFLAGS='${{ matrix.CXXFLAGS }}'
+        CIBW_ENVIRONMENT_PASS_LINUX: CMAKE_ARGS CXXFLAGS VERBOSE
+        CIBW_TEST_COMMAND_WINDOWS: "" # wheels are still broken :(
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        path: wheelhouse/*.whl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,7 @@ elseif(APPLE AND WITH_DMG)
     COMMAND ${Python3_EXECUTABLE} "${CMAKE_MACOSX_GOODIES_PATH}/licenseDMG.py" "${PROJECT_BINARY_DIR}/${CPACK_PACKAGE_FILE_NAME}.dmg" "${LICENSES}"
   )
 
-elseif(UNIX)
+elseif(UNIX AND NOT SKBUILD)
 
   add_subdirectory(dist/flatpak)
 

--- a/pairinteraction/CMakeLists.txt
+++ b/pairinteraction/CMakeLists.txt
@@ -39,7 +39,9 @@ target_compile_definitions(pairinteraction PUBLIC $<$<CXX_COMPILER_ID:MSVC>:NOMI
 add_executable(pairinteraction-backend-deprecated ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
 target_compile_features(pairinteraction-backend-deprecated PRIVATE cxx_std_17)
-set_target_properties(pairinteraction-backend-deprecated PROPERTIES CXX_EXTENSIONS OFF)
+set_target_properties(pairinteraction-backend-deprecated PROPERTIES
+  CXX_EXTENSIONS OFF
+  INSTALL_RPATH $<$<BOOL:${SKBUILD}>:$<$<PLATFORM_ID:Linux>:$ORIGIN>$<$<PLATFORM_ID:Darwin>:@loader_path>>)
 
 target_link_libraries(pairinteraction-backend-deprecated pairinteraction)
 
@@ -312,6 +314,11 @@ if(WITH_PYTHON)
     string(REPLACE "python3${Python3_VERSION_MINOR}.lib" "python3.lib" Python3_LIBRARIES_GENERALIZED ${Python3_LIBRARIES})
     message(STATUS "Unpatched Python3 libraries: ${Python3_LIBRARIES}")
     message(STATUS "  Patched Python3 libraries: ${Python3_LIBRARIES_GENERALIZED}")
+    foreach(Python3_LIBRARY ${Python3_LIBRARIES_GENERALIZED})
+      if(NOT EXISTS ${Python3_LIBRARY})
+        message(FATAL_ERROR "${Python3_LIBRARY}: No such file or directory")
+      endif()
+    endforeach()
   endif()
 
   include(UseSWIG)
@@ -325,13 +332,15 @@ if(WITH_PYTHON)
     SWIG_COMPILE_OPTIONS "-Wall;-py3"
     SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
     SWIG_GENERATED_INCLUDE_DIRECTORIES "${Python3_INCLUDE_DIRS};${Python3_NumPy_INCLUDE_DIRS}"
-    SWIG_GENERATED_COMPILE_OPTIONS $<$<CXX_COMPILER_ID:MSVC>:/bigobj>)
+    SWIG_GENERATED_COMPILE_OPTIONS $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
+    INSTALL_RPATH $<$<BOOL:${SKBUILD}>:$<$<PLATFORM_ID:Linux>:$ORIGIN>$<$<PLATFORM_ID:Darwin>:@loader_path>>)
   target_link_options(binding PUBLIC
     $<$<CXX_COMPILER_ID:AppleClang>:-undefined dynamic_lookup>
     $<$<CXX_COMPILER_ID:Clang,GNU>:-Wl,--unresolved-symbols=ignore-all>
     $<$<CXX_COMPILER_ID:MSVC>:/NODEFAULTLIB:python3${Python3_VERSION_MINOR}.lib /DEFAULTLIB:python3.lib /FORCE:UNRESOLVED>)
   target_link_libraries(binding PUBLIC pairinteraction $<$<CXX_COMPILER_ID:MSVC>:${Python3_LIBRARIES_GENERALIZED}>)
   target_copy_mkl_dlls(binding)
+  get_property(SWIG_MODULE_binding_SUPPORT_FILES TARGET binding PROPERTY SWIG_SUPPORT_FILES)
 
 endif()
 
@@ -354,7 +363,7 @@ if( WITH_DMG )
 
   if(WITH_PYTHON)
     install(TARGETS binding LIBRARY DESTINATION pairinteraction)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/binding.py DESTINATION pairinteraction)
+    install(FILES ${SWIG_MODULE_binding_SUPPORT_FILES} DESTINATION pairinteraction)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pireal.py DESTINATION pairinteraction)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/picomplex.py DESTINATION pairinteraction)
   endif()
@@ -369,17 +378,24 @@ if( WITH_DMG )
 
   install(CODE "execute_process(COMMAND ${Python3_EXECUTABLE} ${CMAKE_MACOSX_GOODIES_PATH}/standalone.py \${CMAKE_INSTALL_PREFIX}/pairinteraction/libraries ${bin1} ${bin2} ${bin3})")
 
-elseif ( NOT WIN32 )
-
-  if(WITH_PYTHON)
-    # Hopefully better in the future... https://gitlab.kitware.com/cmake/cmake/-/issues/24213
-    set(PY_MOD_DIR "lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages/pairinteraction")
-    install(TARGETS binding LIBRARY DESTINATION ${PY_MOD_DIR})
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/binding.py DESTINATION ${PY_MOD_DIR})
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pireal.py DESTINATION ${PY_MOD_DIR})
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/picomplex.py DESTINATION ${PY_MOD_DIR})
-  endif()
+elseif(SKBUILD)
+  install(TARGETS binding LIBRARY DESTINATION ${SKBUILD_PLATLIB_DIR}/pairinteraction)
+  install(TARGETS pairinteraction LIBRARY DESTINATION ${SKBUILD_PLATLIB_DIR}/pairinteraction)
+  install(TARGETS pairinteraction-backend-deprecated RUNTIME DESTINATION ${SKBUILD_PLATLIB_DIR}/pairinteraction)
+  install(FILES ${SWIG_MODULE_binding_SUPPORT_FILES} DESTINATION ${SKBUILD_PLATLIB_DIR}/pairinteraction)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pireal.py DESTINATION ${SKBUILD_PLATLIB_DIR}/pairinteraction)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/picomplex.py DESTINATION ${SKBUILD_PLATLIB_DIR}/pairinteraction)
+  install(FILES ${MKL_DLLS_TO_COPY} DESTINATION ${SKBUILD_PLATLIB_DIR}/pairinteraction)
+elseif(WITH_PYTHON)
+  # Hopefully better in the future... https://gitlab.kitware.com/cmake/cmake/-/issues/24213
+  set(PY_MOD_DIR "lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages/pairinteraction")
+  install(TARGETS binding LIBRARY DESTINATION ${PY_MOD_DIR})
   install(TARGETS pairinteraction LIBRARY DESTINATION lib)
   install(TARGETS pairinteraction-backend-deprecated RUNTIME DESTINATION share/pairinteraction/pairinteraction)
-
-endif( )
+  install(FILES ${SWIG_MODULE_binding_SUPPORT_FILES} DESTINATION ${PY_MOD_DIR})
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pireal.py DESTINATION ${PY_MOD_DIR})
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/picomplex.py DESTINATION ${PY_MOD_DIR})
+else()
+  install(TARGETS pairinteraction LIBRARY DESTINATION lib)
+  install(TARGETS pairinteraction-backend-deprecated RUNTIME DESTINATION share/pairinteraction/pairinteraction)
+endif()

--- a/pairinteraction/databases/CMakeLists.txt
+++ b/pairinteraction/databases/CMakeLists.txt
@@ -31,6 +31,10 @@ if( WITH_DMG )
 
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/quantum_defects.db DESTINATION pairinteraction/databases)
 
+elseif( SKBUILD )
+
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/quantum_defects.db DESTINATION ${SKBUILD_PLATLIB_DIR}/pairinteraction)
+
 else( )
 
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/quantum_defects.db DESTINATION share/pairinteraction/pairinteraction/databases)

--- a/pairinteraction_gui/CMakeLists.txt
+++ b/pairinteraction_gui/CMakeLists.txt
@@ -29,7 +29,7 @@ add_custom_target(gui ALL
 
 # Compile Python scripts
 
-if ( CMAKE_HOST_WIN32 OR (CMAKE_HOST_APPLE AND WITH_DMG) )
+if ( NOT SKBUILD AND (CMAKE_HOST_WIN32 OR (CMAKE_HOST_APPLE AND WITH_DMG)) )
 
   find_program(PYINSTALLER NAMES pyinstaller)
 
@@ -52,7 +52,8 @@ else( )
 
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
   add_custom_command(TARGET gui POST_BUILD
-    COMMAND ${Python3_EXECUTABLE} -m compileall -q ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${CMAKE_COMMAND} -E env "PYTHONPYCACHEPREFIX=${CMAKE_BINARY_DIR}/__pycache__"
+      ${Python3_EXECUTABLE} -m compileall -q ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}
   )
 
@@ -75,6 +76,11 @@ if( CMAKE_HOST_APPLE AND WITH_DMG )
   set(filepath \${CMAKE_INSTALL_PREFIX}/pairinteraction_gui/pairinteraction_gui)
   set(iconpath ${CMAKE_MACOSX_GOODIES_PATH}/pairinteraction.icns)
   install(CODE "execute_process(COMMAND ${FILEICON} set ${filepath} ${iconpath})")
+
+elseif( SKBUILD )
+
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} DESTINATION ${SKBUILD_PLATLIB_DIR})
+  install(PROGRAMS ${CMAKE_BINARY_DIR}/start_pairinteraction_gui DESTINATION ${SKBUILD_SCRIPTS_DIR})
 
 elseif( CMAKE_HOST_UNIX )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = [
+    "scikit-build-core",
+    "swig",
+    "numpy",
+    "pyqt5",
+]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "pairinteraction"
+version = "0.9.9"
+description = "A Rydberg Interaction Calculator"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "GPL-3.0-or-later OR LGPL-3.0-or-later" }
+authors = [
+    { name = "Sebastian Weber" },
+    { name = "Henri Menke" },
+]
+homepage = "https://www.pairinteraction.org"
+repository = "https://github.com/pairinteraction/pairinteraction"
+dependencies = [
+    "numpy",
+    "pint",
+    "pyqt5",
+    "pyqtgraph",
+    "scipy",
+]
+
+[tool.scikit-build]
+cmake.verbose = true
+wheel.packages = []
+wheel.py-api = "py3"
+
+[tool.cibuildwheel]
+build = [
+  "cp38-manylinux_x86_64",
+  "cp38-win_amd64",
+  "cp38-macosx_x86_64",
+]
+build-verbosity = 1
+test-command = [
+  "python -c \"from pairinteraction import pireal as pi; v = pi.VectorDouble(1, 3.14); assert v[0] == 3.14\"",
+  "python -c \"from pairinteraction import picomplex as pi; v = pi.VectorDouble(1, 3.14); assert v[0] == 3.14\"",
+  "python -c \"from pairinteraction_gui import app; assert type(app.version_program) is str\"",
+]
+
+[tool.cibuildwheel.windows]
+before-all = "pip install delvewheel" # build-system.requires is unavailable in the build venv
+repair-wheel-command = "delvewheel repair --ignore-in-wheel -w {dest_dir} {wheel}"
+
+# MACOSX_DEPLOYMENT_TARGET=11.0 is broken: https://github.com/pypa/pip/issues/11789
+[tool.cibuildwheel.macos.environment]
+MACOSX_DEPLOYMENT_TARGET = "10.15"


### PR DESCRIPTION
- [x] Linux wheels
- [x] macOS wheels
- [ ] Windows wheels
  - [x] `error LNK2019: unresolved external symbol __imp_PyUnicode_AsUTF8 referenced in function "void __cdecl SWIG_Python_AddErrorMsg(char const *)" (?SWIG_Python_AddErrorMsg@@YAXPEBD@Z)`
  - [ ] Install MKL DLLs into the wheel somehow?
- [ ] Currently only `cp38` (which ones to add?)
- [ ] Deploy to PyPI on release?