### PR TITLE
[ci] update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ^pairinteraction/unit_test/integration_test_referencedata.txt$|^LICENSE(.*).txt$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -15,24 +15,13 @@ repos:
       - id: clang-format
         args: ["-i", "--style=file"]
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.4.2
+    rev: v1.5.4
     hooks:
       - id: remove-tabs
         exclude: ^apple/Info.plist$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.274
+    rev: v0.1.6
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix"]
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-      - id: black
-        args: ["--line-length", "120"]
-  # Jupyter notebook specific tools
-  - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.7.0
-    hooks:
-      - id: nbqa-ruff
-        args: ["--ignore=E402,I001", "--fix", "--exit-non-zero-on-fix"]
-      - id: nbqa-black
+      - id: ruff-format

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -2,6 +2,7 @@ line-length = 120
 target-version = "py38"
 select = ["F", "E", "B", "C", "W", "I", "UP", "TID25"]
 extend-ignore = ["E741", "C901", "B905"]
+extend-include = ["*.ipynb"]
 
 [per-file-ignores]
 "pairinteraction_gui/app.py" = ["E402"]


### PR DESCRIPTION
Ruff v0.1.2 introduced a code formatter (`ruff format`) similar to black, but of course much faster and with builtin support for Jupyter notebooks.