### PR TITLE
Unpin dependencies for wheel

### DIFF
--- a/setup.py.in
+++ b/setup.py.in
@@ -6,12 +6,14 @@ with open("@CMAKE_SOURCE_DIR@/README.md", "r") as fh:
     long_description = fh.read()
 
 with open("@CMAKE_SOURCE_DIR@/requirements.txt", "r") as fh:
-    install_requires = [str(req) for req in parse_requirements(fh) if req.name not in ["pyinstaller", "wheel"]]
+    install_requires = [
+        str(req).replace("~", ">") for req in parse_requirements(fh) if req.name not in ["pyinstaller", "wheel"]
+    ]
 
 setup(
-    name = "pairinteraction",
+    name="pairinteraction",
     python_requires=">=3.8",
-    version = r"@VERSION_WITHOUT_LEADING_V_COMPACT_ALPHA@",
+    version=r"@VERSION_WITHOUT_LEADING_V_COMPACT_ALPHA@",
     author="Sebastian Weber, Henri Menke, Johannes Mögerle, Johannes Block, Alexander Papageorge",
     description="A Rydberg Interaction Calculator",
     long_description=long_description,
@@ -24,17 +26,11 @@ setup(
         "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     ],
-    packages = find_namespace_packages(include=[
-        "pairinteraction", "pairinteraction_gui", "pairinteraction_gui.pipy"
-    ]),
-    package_data = {
-        "pairinteraction" : [
-            "_binding.so",
-            "pairinteraction-backend-deprecated",
-            "databases/quantum_defects.db"
-        ],
-        "pairinteraction_gui" : [ "conf/example.pconf", "conf/example.sconf", "icon.png" ],
+    packages=find_namespace_packages(include=["pairinteraction", "pairinteraction_gui", "pairinteraction_gui.pipy"]),
+    package_data={
+        "pairinteraction": ["_binding.so", "pairinteraction-backend-deprecated", "databases/quantum_defects.db"],
+        "pairinteraction_gui": ["conf/example.pconf", "conf/example.sconf", "icon.png"],
     },
-    scripts = [ "start_pairinteraction_gui" ],
-    install_requires = install_requires,
+    scripts=["start_pairinteraction_gui"],
+    install_requires=install_requires,
 )


### PR DESCRIPTION
The idea is that we still build with the pinned versions (`~=`), but inside the wheel we only require newer versions (`>=`). This is the most straightforward fix for #170 