### PR TITLE
fix and add python coverage 

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -120,9 +120,9 @@ jobs:
     - name: Setup uv project virtual environment
       uses: ./.github/actions/setup-uv-all-deps
     - name: Install pairinteraction into virtual environment
-      run: uv pip install .[tests]
+      run: uv pip install -e .[tests]  # -e is needed for coverage to work
     - name: Run pytest with coverage
-      run: uv run --no-project coverage run -m pytest
+      run: uv run --no-project coverage run --source=src,tests -m pytest
     - name: Generate Code Coverage
       run: |
         uv run --no-project coverage lcov -o coverage.info

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ dist/
 .pytest_cache/
 .coverage
 coverage.lcov
+coverage.info
+docs/coverage/
 
 # Ignore lockfiles as the software should work for different dependency versions
 uv.lock

--- a/src/pairinteraction/_wrapped/basis/basis.py
+++ b/src/pairinteraction/_wrapped/basis/basis.py
@@ -63,10 +63,12 @@ class BasisBase(ABC, Generic[KetType]):
 
     @property
     def number_of_states(self) -> int:
+        """Return the number of states in the basis."""
         return self._cpp.get_number_of_states()
 
     @property
     def number_of_kets(self) -> int:
+        """Return the number of kets in the basis."""
         return self._cpp.get_number_of_kets()
 
     @property
@@ -75,7 +77,17 @@ class BasisBase(ABC, Generic[KetType]):
         return self.get_coefficients()
 
     def get_coefficients(self) -> "csr_matrix":
-        """Return the coefficients of the basis as a sparse matrix."""
+        """Return the coefficients of the basis as a sparse matrix.
+
+        The coefficients are stored in a sparse matrix with shape (number_of_kets, number_of_states),
+        where the first index correspond to the kets and the second index correspond to the states.
+        For example `basis.get_coefficients()[i, j]` is the i-th coefficient
+        (i.e. the coefficient corresponding to the i-th ket) of the j-th state.
+
+        The coefficients are normalized, i.e. the sum of the absolute values of the coefficients
+        in each row is equal to 1.
+
+        """
         return self._cpp.get_coefficients()
 
     def get_corresponding_state(self: "Self", ket_or_index: Union[KetType, int]) -> "Self":

--- a/src/pairinteraction/_wrapped/enums.py
+++ b/src/pairinteraction/_wrapped/enums.py
@@ -59,3 +59,10 @@ def get_cpp_parity(parity: Parity) -> _backend.Parity:
     if parity not in _ParityDict:
         raise ValueError(f"Unknown parity '{parity}', should be one of {list(_ParityDict.keys())}")
     return _ParityDict[parity]
+
+
+def get_python_parity(parity: _backend.Parity) -> Parity:
+    """Convert a cpp Parity enum to a python Parity string."""
+    if parity not in _ParityDict.values():
+        raise ValueError(f"Unknown parity '{parity}', should be one of {list(_ParityDict.values())}")
+    return next(k for k, v in _ParityDict.items() if v == parity)

--- a/src/pairinteraction/_wrapped/ket/ket.py
+++ b/src/pairinteraction/_wrapped/ket/ket.py
@@ -49,8 +49,16 @@ class KetBase(ABC):
     def __str__(self) -> str:
         return self.get_label("ket")
 
-    def get_label(self, fmt: Literal["ket", "bra", "raw"]) -> str:
-        """Label representing the ket."""
+    def get_label(self, fmt: Literal["raw", "ket", "bra"]) -> str:
+        """Label representing the ket.
+
+        Args:
+            fmt: The format of the label, i.e. whether to return the raw label, or the label in ket or bra notation.
+
+        Returns:
+            The label of the ket in the given format.
+
+        """
         raw = self._cpp.get_label()
         if fmt == "raw":
             return raw

--- a/src/pairinteraction/_wrapped/ket/ket.py
+++ b/src/pairinteraction/_wrapped/ket/ket.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 from abc import ABC
-from typing import TYPE_CHECKING, ClassVar, Literal, Optional, Union, get_args, overload
+from typing import TYPE_CHECKING, ClassVar, Literal, Optional, Union, overload
 
 from typing_extensions import deprecated
 
 from pairinteraction import _backend
-from pairinteraction._wrapped.enums import Parity
+from pairinteraction._wrapped.enums import Parity, get_python_parity
 from pairinteraction.units import QuantityScalar
 
 if TYPE_CHECKING:
@@ -74,10 +74,7 @@ class KetBase(ABC):
     def parity(self) -> Parity:
         """The parity of the ket."""
         parity_cpp = self._cpp.get_parity()
-        parity = parity_cpp.name
-        if parity in get_args(Parity):
-            return parity  # type: ignore [return-value]
-        raise ValueError(f"Unknown parity {parity}")
+        return get_python_parity(parity_cpp)
 
     @property
     @deprecated("Use the `get_energy` method instead. Will be removed in v2.0")

--- a/tests/test_basis_atom.py
+++ b/tests/test_basis_atom.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2024 Pairinteraction Developers
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+import numpy as np
+import pytest
+
+import pairinteraction.real as pi
+
+
+@pytest.fixture
+def basis() -> pi.BasisAtom:
+    """Create a test basis with a few states around Rb 60S."""
+    ket = pi.KetAtom("Rb", n=60, l=0, j=0.5, m=0.5)
+    energy_min = ket.get_energy(unit="GHz") - 100
+    energy_max = ket.get_energy(unit="GHz") + 100
+    return pi.BasisAtom(
+        "Rb",
+        n=(58, 62),
+        l=(0, 2),
+        energy=(energy_min, energy_max),
+        energy_unit="GHz",
+    )
+
+
+def test_basis_creation(basis: pi.BasisAtom) -> None:
+    """Test basic properties of created basis."""
+    assert basis.species == "Rb"
+    assert basis.number_of_kets == 80
+    assert basis.number_of_states == basis.number_of_kets
+    assert len(basis.kets) == basis.number_of_kets
+    assert basis.number_of_kets < pi.BasisAtom("Rb", n=(58, 62), l=(0, 2)).number_of_kets
+    assert all(x in str(basis) for x in ["BasisAtom", "n=(58, 62)", "l=(0, 2)"])
+
+
+def test_coefficients(basis: pi.BasisAtom) -> None:
+    """Test coefficient matrix properties."""
+    coeffs = basis.get_coefficients()
+    assert coeffs.shape == (basis.number_of_kets, basis.number_of_states)
+    assert pytest.approx(coeffs.diagonal()) == 1.0  # NOSONAR
+    assert pytest.approx(coeffs.sum()) == basis.number_of_kets  # NOSONAR
+
+
+def test_get_amplitudes_and_overlaps(basis: pi.BasisAtom) -> None:
+    """Test amplitude and overlap calculations."""
+    ind = 3
+    test_ket = basis.kets[ind]
+
+    amplitudes = basis.get_amplitudes(test_ket)
+    assert len(amplitudes) == basis.number_of_states
+    assert pytest.approx(amplitudes[ind]) == 1.0  # NOSONAR
+
+    overlaps = basis.get_overlaps(test_ket)
+    assert len(overlaps) == basis.number_of_states
+    assert pytest.approx(overlaps[ind]) == 1.0  # NOSONAR
+
+    # Test with another basis
+    matrix_amplitudes = basis.get_amplitudes(basis)
+    assert matrix_amplitudes.shape == (basis.number_of_kets, basis.number_of_states)
+    assert pytest.approx(matrix_amplitudes.diagonal()) == 1.0  # NOSONAR
+
+    matrix_overlaps = basis.get_overlaps(basis)
+    assert matrix_overlaps.shape == (basis.number_of_states, basis.number_of_states)
+    assert pytest.approx(matrix_overlaps.diagonal()) == 1.0  # NOSONAR
+
+
+def test_get_matrix_elements(basis: pi.BasisAtom) -> None:
+    """Test matrix element calculations."""
+    test_ket = basis.kets[0]
+
+    elements_dipole = basis.get_matrix_elements(test_ket, "electric_dipole", q=0, unit="e * a0")
+    assert elements_dipole.shape == (basis.number_of_states,)
+    assert np.count_nonzero(elements_dipole) > 0
+    assert np.count_nonzero(elements_dipole) < basis.number_of_states
+
+    matrix_elements = basis.get_matrix_elements(basis, "electric_dipole", 0, unit="e * a0")
+    assert matrix_elements.shape == (basis.number_of_states, basis.number_of_states)
+    assert np.count_nonzero(matrix_elements.toarray()) > 0
+    assert np.count_nonzero(matrix_elements.toarray()) < basis.number_of_states**2
+
+
+def test_error_handling(basis: pi.BasisAtom) -> None:
+    """Test error cases."""
+    with pytest.raises(TypeError):
+        basis.get_amplitudes("not a ket")  # type: ignore [call-overload]
+
+    with pytest.raises(TypeError):
+        basis.get_overlaps("not a ket")  # type: ignore [call-overload]
+
+    with pytest.raises(TypeError):
+        basis.get_matrix_elements("not a ket", "energy", 0)  # type: ignore [call-overload]

--- a/tests/test_ket.py
+++ b/tests/test_ket.py
@@ -4,6 +4,7 @@
 import pytest
 
 import pairinteraction.real as pi
+from pairinteraction.units import ureg
 
 
 def test_ket() -> None:
@@ -11,5 +12,29 @@ def test_ket() -> None:
     assert ket.species == "Rb"
     assert ket.n == 60
     assert ket.l == 0
+    assert pytest.approx(ket.s) == 0.5  # NOSONAR
     assert pytest.approx(ket.j) == 0.5  # NOSONAR
     assert pytest.approx(ket.m) == 0.5  # NOSONAR
+    assert ket.parity == "even"
+    assert ket.get_energy().units == ureg.Unit("bohr^2 electron_mass/atomic_unit_of_time^2")
+    assert pytest.approx(ket.get_energy().magnitude) == 0.15335264334573842  # NOSONAR
+    assert pytest.approx(ket.get_energy("GHz")) == 1009011.9215883961  # NOSONAR
+
+    assert ket == pi.KetAtom("Rb", n=60, l=0, j=0.5, m=0.5)
+
+    ket_odd = pi.KetAtom("Rb", n=60, l=1, j=1.5, m=-0.5)
+    assert ket_odd.l == 1
+    assert pytest.approx(ket_odd.f) == 1.5  # NOSONAR
+    assert pytest.approx(ket_odd.m) == -0.5  # NOSONAR
+    assert ket_odd.parity == "odd"
+
+    for fmt in ["raw", "ket", "bra"]:
+        label = ket_odd.get_label(fmt)
+        assert all(str(qn) in label for qn in ["Rb", 60, "P", "3/2", "-1/2"])
+
+    assert ket_odd != ket
+    assert ket != pi.KetAtom("Rb", n=60, l=1, j=1.5, m=0.5)
+
+    assert ket.get_matrix_element(ket_odd, "electric_dipole", q=-1) != 0
+    assert ket.get_matrix_element(ket_odd, "electric_dipole", q=0) == 0
+    assert ket.get_matrix_element(ket_odd, "electric_dipole", q=+1) == 0


### PR DESCRIPTION
currently the python coverage only shows the tests folder (and cli.py for some reason).
Fixed this by doing an `pip -e .` install.

Also started adding more tests and docstrings for ket and basis