### PR TITLE
Perturbative: add create_system_for_perturbative

### DIFF
--- a/src/pairinteraction/perturbative/__init__.py
+++ b/src/pairinteraction/perturbative/__init__.py
@@ -2,9 +2,15 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 from pairinteraction.perturbative.perturbative import (
+    create_system_for_perturbative,
     get_c3_from_system,
     get_c6_from_system,
     get_effective_hamiltonian_from_system,
 )
 
-__all__ = ["get_c3_from_system", "get_c6_from_system", "get_effective_hamiltonian_from_system"]
+__all__ = [
+    "create_system_for_perturbative",
+    "get_c3_from_system",
+    "get_c6_from_system",
+    "get_effective_hamiltonian_from_system",
+]


### PR DESCRIPTION
Implement minimal changes for better perturbative calculations.

In a future PR restructure perturbative calculations as class structure ...



# Old comments for reference
# Things to discuss
- do we want to allow passing `min_population_admixture` to `get_c6(...)`, etc.? (already now has 7! arguments)
- changed `check_for_resonances` to only log errors and dont raise Exceptions, also always use `required_overlap=0.9` but maybe allow the user to call the function separately with custom required_overlap
- do we actually want the names `get_c6`, ... Since these are non-trivial calculations I maybe prefer `calc_c6`, ...
- Instead of returning the Perturbed Eigenvectors as sparse matrix, we could also return a list of PairStates
- improve the example notebooks (should we only make examples for `get_c6(...)` or also keep the examples with `get_c6_from_system(...)`


# Related future PR
- #266
- allow passing tuples of (value, unit) instead of pint.Quantities (probably we can then always allow this; this would make the unit argument in e.g. `set_electric_field(value, unit)` redundant ...)