### PR TITLE
Ket pair label

### DIFF
--- a/src/pairinteraction/_wrapped/ket/ket.py
+++ b/src/pairinteraction/_wrapped/ket/ket.py
@@ -42,7 +42,7 @@ class KetBase(ABC):
         return obj
 
     def __repr__(self) -> str:
-        return self.get_label("raw")
+        return f"{type(self).__name__}({self.get_label('raw')})"
 
     def __str__(self) -> str:
         return self.get_label("ket")
@@ -57,7 +57,23 @@ class KetBase(ABC):
             return False
         return self._cpp == other._cpp  # type: ignore [operator]
 
-    def get_label(self, fmt: Literal["raw", "ket", "bra"]) -> str:
+    @property
+    def m(self) -> float:
+        """The magnetic quantum number m (int or half-int)."""
+        return self._cpp.get_quantum_number_m()
+
+    @property
+    def f(self) -> float:
+        """The total momentum quantum number f (int or half-int)."""
+        return self._cpp.get_quantum_number_f()
+
+    @property
+    def parity(self) -> Parity:
+        """The parity of the ket."""
+        parity_cpp = self._cpp.get_parity()
+        return get_python_parity(parity_cpp)
+
+    def get_label(self, fmt: Literal["raw", "ket", "bra"] = "raw") -> str:
         """Label representing the ket.
 
         Args:
@@ -75,22 +91,6 @@ class KetBase(ABC):
         if fmt == "bra":
             return f"⟨{raw}|"
         raise ValueError(f"Unknown fmt {fmt}")
-
-    @property
-    def m(self) -> float:
-        """The magnetic quantum number m (int or half-int)."""
-        return self._cpp.get_quantum_number_m()
-
-    @property
-    def f(self) -> float:
-        """The total momentum quantum number f (int or half-int)."""
-        return self._cpp.get_quantum_number_f()
-
-    @property
-    def parity(self) -> Parity:
-        """The parity of the ket."""
-        parity_cpp = self._cpp.get_parity()
-        return get_python_parity(parity_cpp)
 
     @overload
     def get_energy(self, unit: None = None) -> "PintFloat": ...

--- a/src/pairinteraction/_wrapped/ket/ket_pair.py
+++ b/src/pairinteraction/_wrapped/ket/ket_pair.py
@@ -2,13 +2,16 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 from collections.abc import Sequence
-from typing import Any, ClassVar, Union
+from functools import cached_property
+from typing import Any, ClassVar, Literal, Union
 
 from typing_extensions import TypeGuard
 
 from pairinteraction import _backend
+from pairinteraction._wrapped.basis.basis_atom import BasisAtomComplex, BasisAtomReal
 from pairinteraction._wrapped.ket.ket import KetBase
 from pairinteraction._wrapped.ket.ket_atom import KetAtom
+from pairinteraction._wrapped.state.state_atom import StateAtomComplex, StateAtomReal
 
 UnionCPPKetPair = Union[_backend.KetPairReal, _backend.KetPairComplex]
 UnionTypeCPPKetPairCreator = Any
@@ -39,15 +42,49 @@ class KetPair(KetBase):
 
     _cpp: UnionCPPKetPair
     _cpp_creator: ClassVar[UnionTypeCPPKetPairCreator] = None
+    _TypeBasisAtom: Union[type[BasisAtomReal], type[BasisAtomComplex]]  # should be ClassVar, but cannot be nested yet
+    _TypeStateAtom: Union[type[StateAtomReal], type[StateAtomComplex]]  # should be ClassVar, but cannot be nested yet
 
     def __init__(self) -> None:
         """Creating a KetPair object directly is not possible."""  # noqa: D401
         raise NotImplementedError("KetPair objects cannot be created directly.")
 
+    def get_label(self, fmt: Literal["raw", "ket", "bra", "detailed"] = "raw", *, max_kets: int = 3) -> str:
+        """Label representing the ket pair.
+
+        Args:
+            fmt: The format of the label, i.e. whether to return the raw label, or the label in ket or bra notation.
+            max_kets: Maximum number of single atom kets to include in the label for each StateAtom.
+
+        Returns:
+            A string representation of the ket pair.
+
+        """
+        if fmt == "detailed":
+            atom_labels = [atom.get_label(max_kets=max_kets) for atom in self.state_atoms]
+            return f"({atom_labels[0]}) ⊗ ({atom_labels[1]})"
+        return super().get_label(fmt)
+
+    @cached_property
+    def state_atoms(self) -> Union[tuple[StateAtomReal, StateAtomReal], tuple[StateAtomComplex, StateAtomComplex]]:
+        """Return the state atoms of the ket pair."""
+        state_atoms = []
+        for atomic_state in self._cpp.get_atomic_states():
+            basis = self._TypeBasisAtom._from_cpp_object(atomic_state)
+            state = self._TypeStateAtom._from_basis_object(basis)
+            state_atoms.append(state)
+        return tuple(state_atoms)  # type: ignore [return-value]
+
 
 class KetPairReal(KetPair):
     _cpp: _backend.KetPairReal
+    _TypeBasisAtom = BasisAtomReal
+    _TypeStateAtom = StateAtomReal
+    state_atoms: tuple[StateAtomReal, StateAtomReal]
 
 
 class KetPairComplex(KetPair):
     _cpp: _backend.KetPairComplex
+    _TypeBasisAtom = BasisAtomComplex
+    _TypeStateAtom = StateAtomComplex
+    state_atoms: tuple[StateAtomComplex, StateAtomComplex]

--- a/src/pairinteraction/_wrapped/state/state.py
+++ b/src/pairinteraction/_wrapped/state/state.py
@@ -58,6 +58,9 @@ class StateBase(ABC, Generic[BasisType, KetType]):
     def get_label(self, max_kets: int = 3) -> str:
         """Label representing the state.
 
+        Args:
+            max_kets: Maximum number of kets to include in the label.
+
         Returns:
             The label of the ket in the given format.
 
@@ -65,17 +68,17 @@ class StateBase(ABC, Generic[BasisType, KetType]):
         coefficients = self.get_coefficients()
         sorted_inds = np.argsort(np.abs(coefficients))[::-1]
         norm_squared = self.norm**2
-        raw = ""
+        label = ""
         overlap = 0
         for i, ind in enumerate(sorted_inds, 1):
-            raw += f"{coefficients[ind]:.2f} {self.kets[ind].get_label('ket')}"
+            label += f"{coefficients[ind]:.2f} {self.kets[ind].get_label('ket')}"
             overlap += abs(coefficients[ind]) ** 2
             if overlap > (0.95 * norm_squared) or i >= max_kets:
                 break
-            raw += " + "
+            label += " + "
         if overlap <= norm_squared - 100 * np.finfo(float).eps:
-            raw += " + ... "
-        return raw
+            label += " + ... "
+        return label
 
     @property
     def kets(self) -> list[KetType]:

--- a/tests/test_pair_potential.py
+++ b/tests/test_pair_potential.py
@@ -40,7 +40,7 @@ def test_pair_potential(generate_reference: bool) -> None:
     np.testing.assert_allclose(np.sum(overlaps, axis=1), np.ones(5))
 
     # Compare to reference data
-    kets = [repr(ket) for ket in basis_pair.kets]
+    kets = [ket.get_label("raw") for ket in basis_pair.kets]
     eigenenergies = np.array([system.get_eigenenergies(unit="GHz") for system in system_pairs])
     eigenvectors = np.array([system.get_eigenbasis().get_coefficients().todense().A1 for system in system_pairs])
 

--- a/tests/test_starkmap.py
+++ b/tests/test_starkmap.py
@@ -28,7 +28,7 @@ def test_starkmap(generate_reference: bool) -> None:
     overlaps = np.array([system.basis.get_overlaps(ket) for system in systems])
 
     # Compare to reference data
-    kets = [repr(ket) for ket in systems[0].basis.kets]
+    kets = [ket.get_label("raw") for ket in systems[0].basis.kets]
     eigenenergies = np.array([system.get_eigenenergies(unit="GHz") for system in systems])
     eigenvectors = np.array([system.get_eigenbasis().get_coefficients().todense().A1 for system in systems])
 


### PR DESCRIPTION
This will result in the following formatting of ket_atom and ket_pair objects

```
repr(ket_atom) = 'KetAtom(Rb:80,P_1/2,1/2)'
str(ket_atom) = '|Rb:80,P_1/2,1/2⟩'
repr(ket_pair) = 'KetPairReal(~Rb:79,P_1/2,-1/2; ~Rb:81,P_1/2,1/2)'
str(ket_pair) = '|~Rb:79,P_1/2,-1/2; ~Rb:81,P_1/2,1/2⟩'
ket_pair.get_label('detailed') = '(0.94 |Rb:79,P_1/2,-1/2⟩ + 0.23 |Rb:79,P_3/2,-1/2⟩ + -0.15 |Rb:78,D_3/2,3/2⟩ + ... ) ⊗ (0.93 |Rb:81,P_1/2,1/2⟩ + 0.23 |Rb:80,D_3/2,-1/2⟩ + -0.12 |Rb:80,D_3/2,3/2⟩ + ... )'
```