### PR TITLE
test-install-from-sdist use python 3.9

### DIFF
--- a/.github/actions/setup-uv-all-deps/action.yml
+++ b/.github/actions/setup-uv-all-deps/action.yml
@@ -1,5 +1,10 @@
 name: 'setup-uv-all-deps'
 
+inputs:
+  python-version:
+    description: "The Python version to use"
+    required: false  # if not provided, uv will default to the newest stable python version
+
 runs:
   using: "composite"
   steps:
@@ -7,7 +12,7 @@ runs:
       uses: astral-sh/setup-uv@v6
       with:
         version: "0.7"
-        python-version: 3.12
+        python-version: ${{ inputs.python-version }}
         enable-cache: true
         cache-dependency-glob: |
           ./pyproject.toml

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -113,6 +113,8 @@ jobs:
 
     - name: Setup uv project virtual environment
       uses: ./.github/actions/setup-uv-all-deps
+      with:
+        python-version: 3.9
 
     - name: Download the sdist
       uses: actions/download-artifact@v5


### PR DESCRIPTION
Since we had multiple occasions, where a version publish failed due to version compatibility problems with python 3.9 (which so far was only tested on tag releases) we now always test in in build from sdist