### PR TITLE
bugfix effective system pair

### DIFF
--- a/src/pairinteraction/perturbative/effective_system_pair.py
+++ b/src/pairinteraction/perturbative/effective_system_pair.py
@@ -137,6 +137,8 @@ class EffectiveSystemPair:
         self._eff_h_dict_au = None
         self._eff_vecs = None
         self._eff_basis = None
+        with contextlib.suppress(AttributeError):
+            del self.model_inds
 
         parts_order: list[BasisSystemLiteral] = ["system_pair", "basis_pair", "system_atoms", "basis_atoms"]
         for part in parts_order:


### PR DESCRIPTION
so far the effective system pair did not delete the cached model inds, which when using the same instance multiple times created unexpected results.
this is a simple fix for that problem.

However, I am not sure, whether one should look again into how the effective system class handles creation and deletion of attributes when using the same instance for different calculations to ensure no similar problems happen in the future.