### PR TITLE
C++ simplify get_matrix_elements

### DIFF
--- a/src/cpp/bindings/basis/Basis.py.cpp
+++ b/src/cpp/bindings/basis/Basis.py.cpp
@@ -51,12 +51,6 @@ static void declare_basis(nb::module_ &m, std::string const &type_name) {
             "transformed",
             nb::overload_cast<const Transformation<scalar_t> &>(&Basis<T>::transformed, nb::const_))
         .def("transformed", nb::overload_cast<const Sorting &>(&Basis<T>::transformed, nb::const_))
-        .def("get_matrix_elements",
-             nb::overload_cast<std::shared_ptr<const typename Basis<T>::ket_t>, OperatorType, int>(
-                 &Basis<T>::get_matrix_elements, nb::const_))
-        .def("get_matrix_elements",
-             nb::overload_cast<std::shared_ptr<const T>, OperatorType, int>(
-                 &Basis<T>::get_matrix_elements, nb::const_))
         .def("get_corresponding_state",
              nb::overload_cast<size_t>(&Basis<T>::get_corresponding_state, nb::const_))
         .def("get_corresponding_state",
@@ -87,6 +81,7 @@ template <typename T>
 static void declare_basis_atom(nb::module_ &m, std::string const &type_name) {
     std::string pyclass_name = "BasisAtom" + type_name;
     nb::class_<BasisAtom<T>, Basis<BasisAtom<T>>> pyclass(m, pyclass_name.c_str());
+    pyclass.def("get_matrix_elements", &BasisAtom<T>::get_matrix_elements);
 }
 
 template <typename T>
@@ -117,22 +112,7 @@ template <typename T>
 static void declare_basis_pair(nb::module_ &m, std::string const &type_name) {
     std::string pyclass_name = "BasisPair" + type_name;
     nb::class_<BasisPair<T>, Basis<BasisPair<T>>> pyclass(m, pyclass_name.c_str());
-    pyclass
-        .def("get_matrix_elements",
-             nb::overload_cast<std::shared_ptr<const BasisPair<T>>, OperatorType, OperatorType, int,
-                               int>(&BasisPair<T>::get_matrix_elements, nb::const_))
-        .def("get_matrix_elements",
-             nb::overload_cast<std::shared_ptr<const BasisAtom<T>>,
-                               std::shared_ptr<const BasisAtom<T>>, OperatorType, OperatorType, int,
-                               int>(&BasisPair<T>::get_matrix_elements, nb::const_))
-        .def("get_matrix_elements",
-             nb::overload_cast<std::shared_ptr<const typename BasisPair<T>::ket_t>, OperatorType,
-                               OperatorType, int, int>(&BasisPair<T>::get_matrix_elements,
-                                                       nb::const_))
-        .def("get_matrix_elements",
-             nb::overload_cast<std::shared_ptr<const KetAtom>, std::shared_ptr<const KetAtom>,
-                               OperatorType, OperatorType, int, int>(
-                 &BasisPair<T>::get_matrix_elements, nb::const_))
+    pyclass.def("get_matrix_elements", &BasisPair<T>::get_matrix_elements)
         .def("get_basis1", &BasisPair<T>::get_basis1)
         .def("get_basis2", &BasisPair<T>::get_basis2);
 }
@@ -141,8 +121,11 @@ template <typename T>
 static void declare_basis_pair_creator(nb::module_ &m, std::string const &type_name) {
     std::string pyclass_name = "BasisPairCreator" + type_name;
     nb::class_<BasisPairCreator<T>> pyclass(m, pyclass_name.c_str());
-    pyclass.def(nb::init<>())
-        .def("add", &BasisPairCreator<T>::add)
+    pyclass
+        .def(nb::init<>())
+        // keep_alive because add() stores only a reference to the system, which must outlive the
+        // creator (the system is dereferenced in create())
+        .def("add", &BasisPairCreator<T>::add, nb::keep_alive<1, 2>())
         .def("restrict_energy", &BasisPairCreator<T>::restrict_energy)
         .def("restrict_quantum_number_m", &BasisPairCreator<T>::restrict_quantum_number_m)
         .def("restrict_parity_under_inversion",

--- a/src/cpp/include/pairinteraction/basis/Basis.hpp
+++ b/src/cpp/include/pairinteraction/basis/Basis.hpp
@@ -18,7 +18,6 @@
 namespace pairinteraction {
 enum class Parity : int;
 enum class TransformationType : unsigned char;
-enum class OperatorType;
 
 /**
  * @class Basis
@@ -71,10 +70,6 @@ public:
     const Eigen::SparseMatrix<scalar_t, Eigen::RowMajor> &get_coefficients() const;
     Eigen::SparseMatrix<scalar_t, Eigen::RowMajor> &get_coefficients();
     void set_coefficients(const Eigen::SparseMatrix<scalar_t, Eigen::RowMajor> &values);
-    virtual Eigen::VectorX<scalar_t> get_matrix_elements(std::shared_ptr<const ket_t> ket,
-                                                         OperatorType type, int q = 0) const = 0;
-    Eigen::SparseMatrix<scalar_t, Eigen::RowMajor> virtual get_matrix_elements(
-        std::shared_ptr<const Derived> other, OperatorType type, int q = 0) const = 0;
 
     class Iterator {
     public:

--- a/src/cpp/include/pairinteraction/basis/BasisAtom.hpp
+++ b/src/cpp/include/pairinteraction/basis/BasisAtom.hpp
@@ -13,6 +13,8 @@
 #include <vector>
 
 namespace pairinteraction {
+enum class OperatorType;
+
 class Database;
 
 class KetAtom;
@@ -57,11 +59,8 @@ public:
 
     int get_ket_index_from_id(size_t ket_id) const;
 
-    Eigen::VectorX<Scalar> get_matrix_elements(std::shared_ptr<const ket_t> ket, OperatorType type,
-                                               int q = 0) const override;
     Eigen::SparseMatrix<Scalar, Eigen::RowMajor>
-    get_matrix_elements(std::shared_ptr<const Type> other, OperatorType type,
-                        int q = 0) const override;
+    get_matrix_elements(std::shared_ptr<const Type> other, OperatorType type, int q) const;
 
 private:
     std::string canonical_basis_id;

--- a/src/cpp/include/pairinteraction/basis/BasisPair.hpp
+++ b/src/cpp/include/pairinteraction/basis/BasisPair.hpp
@@ -18,6 +18,8 @@
 #include <vector>
 
 namespace pairinteraction {
+enum class OperatorType;
+
 template <typename Scalar>
 class BasisPairCreator;
 
@@ -29,8 +31,6 @@ class BasisPair;
 
 template <typename Scalar>
 class BasisAtom;
-
-class KetAtom;
 
 template <typename Scalar>
 struct traits::CrtpTraits<BasisPair<Scalar>> {
@@ -68,24 +68,9 @@ public:
     std::shared_ptr<const BasisAtom<Scalar>> get_basis2() const;
     int get_ket_index_from_tuple(size_t state_index1, size_t state_index2) const;
 
-    Eigen::VectorX<Scalar> get_matrix_elements(std::shared_ptr<const ket_t> /*ket*/,
-                                               OperatorType /*type*/, int /*q*/) const override;
-    Eigen::SparseMatrix<Scalar, Eigen::RowMajor>
-    get_matrix_elements(std::shared_ptr<const Type> /*final_state*/, OperatorType /*type*/,
-                        int /*q*/) const override;
-    Eigen::VectorX<Scalar> get_matrix_elements(std::shared_ptr<const ket_t> ket, OperatorType type1,
-                                               OperatorType type2, int q1 = 0, int q2 = 0) const;
-    Eigen::VectorX<Scalar> get_matrix_elements(std::shared_ptr<const KetAtom> ket1,
-                                               std::shared_ptr<const KetAtom> ket2,
-                                               OperatorType type1, OperatorType type2, int q1 = 0,
-                                               int q2 = 0) const;
     Eigen::SparseMatrix<Scalar, Eigen::RowMajor>
     get_matrix_elements(std::shared_ptr<const Type> final_state, OperatorType type1,
-                        OperatorType type2, int q1 = 0, int q2 = 0) const;
-    Eigen::SparseMatrix<Scalar, Eigen::RowMajor>
-    get_matrix_elements(std::shared_ptr<const BasisAtom<Scalar>> final1,
-                        std::shared_ptr<const BasisAtom<Scalar>> final2, OperatorType type1,
-                        OperatorType type2, int q1 = 0, int q2 = 0) const;
+                        OperatorType type2, int q1, int q2) const;
 
 private:
     map_range_t map_range_of_state_index2;

--- a/src/cpp/src/basis/BasisAtom.cpp
+++ b/src/cpp/src/basis/BasisAtom.cpp
@@ -3,7 +3,6 @@
 
 #include "pairinteraction/basis/BasisAtom.hpp"
 
-#include "pairinteraction/basis/BasisAtomCreator.hpp"
 #include "pairinteraction/database/Database.hpp"
 #include "pairinteraction/ket/KetAtom.hpp"
 
@@ -41,22 +40,6 @@ int BasisAtom<Scalar>::get_ket_index_from_id(size_t ket_id) const {
 template <typename Scalar>
 const std::string &BasisAtom<Scalar>::get_canonical_basis_id() const {
     return canonical_basis_id;
-}
-
-template <typename Scalar>
-Eigen::VectorX<Scalar> BasisAtom<Scalar>::get_matrix_elements(std::shared_ptr<const ket_t> ket,
-                                                              OperatorType type, int q) const {
-    auto final_state = BasisAtomCreator<Scalar>().add_ket(ket).create(database);
-
-    auto matrix_elements = this->get_database().get_matrix_elements_in_canonical_basis(
-        this->shared_from_this(), final_state, type, q);
-    matrix_elements =
-        final_state->get_coefficients().adjoint() * matrix_elements * this->get_coefficients();
-
-    assert(static_cast<size_t>(matrix_elements.rows()) == 1);
-    assert(static_cast<size_t>(matrix_elements.cols()) == this->get_number_of_states());
-
-    return matrix_elements.row(0);
 }
 
 template <typename Scalar>

--- a/src/cpp/src/basis/BasisAtomCreator.test.cpp
+++ b/src/cpp/src/basis/BasisAtomCreator.test.cpp
@@ -140,14 +140,17 @@ DOCTEST_TEST_CASE("calculation of matrix elements") {
     SystemAtom<double> system(basis);
 
     DOCTEST_SUBCASE("calculate energy") {
-        auto m1 = BasisAtomCreator<double>().add_ket(ket_s).create(database)->get_matrix_elements(
-            ket_s, OperatorType::ENERGY, 0);
-        DOCTEST_CHECK(m1.size() == 1);
-        double energy1 = m1[0];
+        auto basis_ket_s = BasisAtomCreator<double>().add_ket(ket_s).create(database);
 
-        auto m2 = basis->get_matrix_elements(ket_s, OperatorType::ENERGY, 0);
-        DOCTEST_CHECK(m2.size() == basis->get_number_of_states());
-        double energy2 = m2[static_cast<int>(basis->get_corresponding_state_index(ket_s))];
+        auto m1 = basis_ket_s->get_matrix_elements(basis_ket_s, OperatorType::ENERGY, 0);
+        DOCTEST_CHECK(m1.rows() == 1);
+        DOCTEST_CHECK(m1.cols() == 1);
+        double energy1 = m1.coeff(0, 0);
+
+        auto m2 = basis->get_matrix_elements(basis_ket_s, OperatorType::ENERGY, 0);
+        DOCTEST_CHECK(m2.rows() == 1);
+        DOCTEST_CHECK(m2.cols() == basis->get_number_of_states());
+        double energy2 = m2.coeff(0, static_cast<int>(basis->get_corresponding_state_index(ket_s)));
 
         double reference = ket_s->get_energy();
         DOCTEST_CHECK(std::abs(energy1 - reference) < 1e-11);
@@ -155,9 +158,12 @@ DOCTEST_TEST_CASE("calculation of matrix elements") {
     }
 
     DOCTEST_SUBCASE("calculate electric dipole matrix element") {
-        auto m = basis->get_matrix_elements(ket_p, OperatorType::ELECTRIC_DIPOLE, 0);
-        DOCTEST_CHECK(m.size() == basis->get_number_of_states());
-        double dipole = m[static_cast<int>(basis->get_corresponding_state_index(ket_s))];
+        auto basis_ket_p = BasisAtomCreator<double>().add_ket(ket_p).create(database);
+
+        auto m = basis->get_matrix_elements(basis_ket_p, OperatorType::ELECTRIC_DIPOLE, 0);
+        DOCTEST_CHECK(m.rows() == 1);
+        DOCTEST_CHECK(m.cols() == basis->get_number_of_states());
+        double dipole = m.coeff(0, static_cast<int>(basis->get_corresponding_state_index(ket_s)));
 
         DOCTEST_CHECK(std::abs(dipole - 1247.6043831131365) < 1e-6);
     }

--- a/src/cpp/src/basis/BasisPair.cpp
+++ b/src/cpp/src/basis/BasisPair.cpp
@@ -4,18 +4,13 @@
 #include "pairinteraction/basis/BasisPair.hpp"
 
 #include "pairinteraction/basis/BasisAtom.hpp"
-#include "pairinteraction/basis/BasisAtomCreator.hpp"
-#include "pairinteraction/basis/BasisPairCreator.hpp"
 #include "pairinteraction/database/Database.hpp"
-#include "pairinteraction/ket/KetAtom.hpp"
 #include "pairinteraction/ket/KetPair.hpp"
-#include "pairinteraction/system/SystemAtom.hpp"
 #include "pairinteraction/utils/Range.hpp"
 #include "pairinteraction/utils/tensor.hpp"
 
 #include <cassert>
 #include <memory>
-#include <oneapi/tbb.h>
 #include <vector>
 
 namespace pairinteraction {
@@ -55,20 +50,6 @@ int BasisPair<Scalar>::get_ket_index_from_tuple(size_t state_index1, size_t stat
 }
 
 template <typename Scalar>
-Eigen::VectorX<Scalar> BasisPair<Scalar>::get_matrix_elements(std::shared_ptr<const ket_t> /*ket*/,
-                                                              OperatorType /*type*/,
-                                                              int /*q*/) const {
-    throw std::invalid_argument("It is required to specify one operator for each atom.");
-}
-
-template <typename Scalar>
-Eigen::SparseMatrix<Scalar, Eigen::RowMajor>
-BasisPair<Scalar>::get_matrix_elements(std::shared_ptr<const Type> /*final_state*/,
-                                       OperatorType /*type*/, int /*q*/) const {
-    throw std::invalid_argument("It is required to specify one operator for each atom.");
-}
-
-template <typename Scalar>
 Eigen::SparseMatrix<Scalar, Eigen::RowMajor>
 BasisPair<Scalar>::get_matrix_elements(std::shared_ptr<const Type> final_state, OperatorType type1,
                                        OperatorType type2, int q1, int q2) const {
@@ -91,47 +72,6 @@ BasisPair<Scalar>::get_matrix_elements(std::shared_ptr<const Type> final_state, 
     assert(static_cast<size_t>(matrix_elements.cols()) == this->get_number_of_kets());
 
     return final_state->get_coefficients().adjoint() * matrix_elements * this->get_coefficients();
-}
-
-template <typename Scalar>
-Eigen::SparseMatrix<Scalar, Eigen::RowMajor>
-BasisPair<Scalar>::get_matrix_elements(std::shared_ptr<const BasisAtom<Scalar>> final1,
-                                       std::shared_ptr<const BasisAtom<Scalar>> final2,
-                                       OperatorType type1, OperatorType type2, int q1,
-                                       int q2) const {
-    // Construct a pair basis with the two single-atom bases
-    auto system1 = SystemAtom<Scalar>(final1);
-    auto system2 = SystemAtom<Scalar>(final2);
-    auto final_state = BasisPairCreator<Scalar>().add(system1).add(system2).create();
-    assert(final_state->get_number_of_states() ==
-           final1->get_number_of_states() * final2->get_number_of_states());
-    assert(final_state->get_number_of_kets() ==
-           final1->get_number_of_states() * final2->get_number_of_states());
-
-    return this->get_matrix_elements(final_state, type1, type2, q1, q2);
-}
-
-template <typename Scalar>
-Eigen::VectorX<Scalar>
-BasisPair<Scalar>::get_matrix_elements(std::shared_ptr<const ket_t> ket, OperatorType type1,
-                                       OperatorType type2, int q1, int q2) const {
-    auto atomic_states = ket->get_atomic_states();
-    return this->get_matrix_elements(atomic_states[0], atomic_states[1], type1, type2, q1, q2)
-        .row(0);
-}
-
-template <typename Scalar>
-Eigen::VectorX<Scalar>
-BasisPair<Scalar>::get_matrix_elements(std::shared_ptr<const KetAtom> ket1,
-                                       std::shared_ptr<const KetAtom> ket2, OperatorType type1,
-                                       OperatorType type2, int q1, int q2) const {
-    auto initial1 = this->get_basis1();
-    auto initial2 = this->get_basis2();
-
-    auto final1 = BasisAtomCreator<Scalar>().add_ket(ket1).create(initial1->get_database());
-    auto final2 = BasisAtomCreator<Scalar>().add_ket(ket2).create(initial2->get_database());
-
-    return this->get_matrix_elements(final1, final2, type1, type2, q1, q2).row(0);
 }
 
 // Explicit instantiations

--- a/src/cpp/src/basis/BasisPairCreator.test.cpp
+++ b/src/cpp/src/basis/BasisPairCreator.test.cpp
@@ -101,6 +101,15 @@ build_manual_symmetrizer(const std::shared_ptr<const BasisPair<Scalar>> &basis,
 }
 
 template <typename Scalar>
+std::shared_ptr<const BasisPair<Scalar>>
+build_pair_basis(std::shared_ptr<const BasisAtom<Scalar>> basis1,
+                 std::shared_ptr<const BasisAtom<Scalar>> basis2) {
+    auto system1 = SystemAtom<Scalar>(std::move(basis1));
+    auto system2 = SystemAtom<Scalar>(std::move(basis2));
+    return BasisPairCreator<Scalar>().add(system1).add(system2).create();
+}
+
+template <typename Scalar>
 void check_same_pair_eigenenergies(const std::shared_ptr<const BasisPair<Scalar>> &basis1,
                                    const std::shared_ptr<const BasisPair<Scalar>> &basis2,
                                    const DiagonalizerEigen<Scalar> &diagonalizer) {
@@ -175,11 +184,14 @@ DOCTEST_TEST_CASE("create a BasisPair") {
     }
 
     DOCTEST_SUBCASE("check overlap") {
-        auto overlaps = basis_pair_a
-                            ->get_matrix_elements(ket, ket, OperatorType::IDENTITY,
-                                                  OperatorType::IDENTITY, 0, 0)
-                            .cwiseAbs2()
-                            .eval();
+        auto basis_ket = BasisAtomCreator<double>().add_ket(ket).create(database);
+        auto basis_pair_ket = build_pair_basis<double>(basis_ket, basis_ket);
+        Eigen::RowVectorXd amplitudes =
+            basis_pair_a
+                ->get_matrix_elements(basis_pair_ket, OperatorType::IDENTITY,
+                                      OperatorType::IDENTITY, 0, 0)
+                .row(0);
+        auto overlaps = amplitudes.cwiseAbs2().eval();
 
         // The total overlap is less than 1 because of the restricted energy window
         DOCTEST_CHECK(overlaps.sum() == doctest::Approx(0.9107819201));
@@ -239,36 +251,44 @@ DOCTEST_TEST_CASE("get matrix elements in the pair basis") {
         DOCTEST_CHECK(matrix_elements_all.cols() == basis_pair_unperturbed->get_number_of_states());
 
         // <ket_pair|d0d0|basis_pair_unperturbed>
-        auto ket_pair = basis_pair_unperturbed->get_kets()[0];
-        auto matrix_elements_ket_pair = basis_pair_unperturbed->get_matrix_elements(
-            ket_pair, OperatorType::ELECTRIC_DIPOLE, OperatorType::ELECTRIC_DIPOLE, 0, 0);
+        auto atomic_states = basis_pair_unperturbed->get_kets()[0]->get_atomic_states();
+        auto basis_pair_ket_pair = build_pair_basis<double>(atomic_states[0], atomic_states[1]);
+        Eigen::RowVectorXd matrix_elements_ket_pair =
+            basis_pair_unperturbed
+                ->get_matrix_elements(basis_pair_ket_pair, OperatorType::ELECTRIC_DIPOLE,
+                                      OperatorType::ELECTRIC_DIPOLE, 0, 0)
+                .row(0);
         DOCTEST_CHECK(matrix_elements_ket_pair.size() ==
                       basis_pair_unperturbed->get_number_of_states());
 
         {
-            Eigen::VectorX<double> ref = matrix_elements_all.row(0);
+            Eigen::RowVectorXd ref = matrix_elements_all.row(0);
             DOCTEST_CHECK(ref.isApprox(matrix_elements_ket_pair, 1e-11));
         }
 
         // <basis x basis|d0d0|basis_pair>
+        auto basis_pair_product = build_pair_basis<double>(basis, basis);
         auto matrix_elements_product = basis_pair->get_matrix_elements(
-            basis, basis, OperatorType::ELECTRIC_DIPOLE, OperatorType::ELECTRIC_DIPOLE, 0, 0);
+            basis_pair_product, OperatorType::ELECTRIC_DIPOLE, OperatorType::ELECTRIC_DIPOLE, 0, 0);
         DOCTEST_CHECK(matrix_elements_product.rows() ==
                       basis->get_number_of_states() * basis->get_number_of_states());
         DOCTEST_CHECK(matrix_elements_product.cols() == basis_pair->get_number_of_states());
 
         // <ket,ket|d0d0|basis_pair>
+        auto basis_ket = BasisAtomCreator<double>().add_ket(ket).create(database);
+        auto basis_pair_ket = build_pair_basis<double>(basis_ket, basis_ket);
         auto matrix_elements_ket = basis_pair->get_matrix_elements(
-            ket, ket, OperatorType::ELECTRIC_DIPOLE, OperatorType::ELECTRIC_DIPOLE, 0, 0);
-        DOCTEST_CHECK(matrix_elements_ket.size() == basis_pair->get_number_of_states());
+            basis_pair_ket, OperatorType::ELECTRIC_DIPOLE, OperatorType::ELECTRIC_DIPOLE, 0, 0);
+        DOCTEST_CHECK(matrix_elements_ket.rows() == 1);
+        DOCTEST_CHECK(matrix_elements_ket.cols() == basis_pair->get_number_of_states());
     }
 
     DOCTEST_SUBCASE("check matrix elements") {
         // energy
         auto hamiltonian = basis_pair->get_matrix_elements(basis_pair, OperatorType::ENERGY,
-                                                           OperatorType::IDENTITY);
+                                                           OperatorType::IDENTITY, 0, 0);
         hamiltonian += basis_pair->get_matrix_elements(basis_pair, OperatorType::IDENTITY,
-                                                       OperatorType::ENERGY);
+                                                       OperatorType::ENERGY, 0, 0);
 
         // interaction with electric field
         {
@@ -345,7 +365,7 @@ DOCTEST_TEST_CASE("get amplitudes (via matrix elements) between different pair b
                   small_unperturbed_basis->get_number_of_states());
 
     auto amplitudes = state_in_perturbed_basis->get_matrix_elements(
-        small_unperturbed_basis, OperatorType::IDENTITY, OperatorType::IDENTITY);
+        small_unperturbed_basis, OperatorType::IDENTITY, OperatorType::IDENTITY, 0, 0);
     DOCTEST_CHECK(amplitudes.rows() == small_unperturbed_basis->get_number_of_states());
     DOCTEST_CHECK(amplitudes.cols() == state_in_perturbed_basis->get_number_of_states());
 }

--- a/src/cpp/tests/test_pair_potential.cpp
+++ b/src/cpp/tests/test_pair_potential.cpp
@@ -95,6 +95,11 @@ int main(int argc, char **argv) {
         kets.push_back(ss.str());
     }
 
+    auto basis_ket = pairinteraction::BasisAtomCreator<double>().add_ket(ket).create(database);
+    auto system_ket = pairinteraction::SystemAtom<double>(basis_ket);
+    auto basis_pair_ket =
+        pairinteraction::BasisPairCreator<double>().add(system_ket).add(system_ket).create();
+
     for (Eigen::Index i = 0; i < static_cast<Eigen::Index>(system_pairs.size()); ++i) {
         eigenenergies.row(i) = system_pairs[i].get_eigenenergies() * HARTREE_IN_GHZ;
 
@@ -102,12 +107,13 @@ int main(int argc, char **argv) {
             system_pairs[i].get_eigenbasis()->get_coefficients().toDense().transpose();
         eigenstates.row(i) = Eigen::Map<Eigen::VectorXd>(tmp.data(), tmp.size());
 
-        overlaps.row(i) =
+        Eigen::RowVectorXd amplitudes =
             system_pairs[i]
                 .get_eigenbasis()
-                ->get_matrix_elements(ket, ket, pairinteraction::OperatorType::IDENTITY,
+                ->get_matrix_elements(basis_pair_ket, pairinteraction::OperatorType::IDENTITY,
                                       pairinteraction::OperatorType::IDENTITY, 0, 0)
-                .cwiseAbs2();
+                .row(0);
+        overlaps.row(i) = amplitudes.cwiseAbs2();
     }
 
     // Compare with reference data

--- a/src/cpp/tests/test_starkmap.cpp
+++ b/src/cpp/tests/test_starkmap.cpp
@@ -83,6 +83,8 @@ int main(int argc, char **argv) {
         kets.push_back(ss.str());
     }
 
+    auto basis_ket = pairinteraction::BasisAtomCreator<double>().add_ket(ket).create(database);
+
     for (Eigen::Index i = 0; i < static_cast<Eigen::Index>(systems.size()); ++i) {
         eigenenergies.row(i) = systems[i].get_eigenenergies() * HARTREE_IN_GHZ;
 
@@ -90,10 +92,12 @@ int main(int argc, char **argv) {
             systems[i].get_eigenbasis()->get_coefficients().toDense().transpose();
         eigenstates.row(i) = Eigen::Map<Eigen::VectorXd>(tmp.data(), tmp.size());
 
-        overlaps.row(i) = systems[i]
-                              .get_eigenbasis()
-                              ->get_matrix_elements(ket, pairinteraction::OperatorType::IDENTITY, 0)
-                              .cwiseAbs2();
+        Eigen::RowVectorXd amplitudes =
+            systems[i]
+                .get_eigenbasis()
+                ->get_matrix_elements(basis_ket, pairinteraction::OperatorType::IDENTITY, 0)
+                .row(0);
+        overlaps.row(i) = amplitudes.cwiseAbs2();
     }
 
     // Compare with reference data

--- a/src/pairinteraction/basis/basis_atom.py
+++ b/src/pairinteraction/basis/basis_atom.py
@@ -363,7 +363,9 @@ class BasisAtom(BasisBase[KetAtom, StateAtom]):
 
         matrix_elements_au: NDArray
         if isinstance(other, KetAtom):
-            matrix_elements_au = np.array(self._cpp.get_matrix_elements(other._cpp, cpp_op, q))
+            is_real = isinstance(self._cpp, _backend.BasisAtomReal)
+            other_cpp = get_cpp_basis_atom_from_ket(other, real=is_real)
+            matrix_elements_au = self._cpp.get_matrix_elements(other_cpp, cpp_op, q).toarray().ravel()
             return QuantityArray.convert_au_to_user(matrix_elements_au, operator, unit)
         if isinstance(other, StateAtom):
             matrix_elements_au = self._cpp.get_matrix_elements(other._cpp, cpp_op, q).toarray().ravel()
@@ -379,3 +381,14 @@ class BasisAtomReal(BasisAtom):
     _cpp_creator = _backend.BasisAtomCreatorReal  # type: ignore [assignment]
     _ket_class = KetAtom
     _state_class = StateAtomReal
+
+
+def get_cpp_basis_atom_from_ket(ket: KetAtom, *, real: bool) -> _backend.BasisAtomComplex:
+    """Create a cpp BasisAtom object containing only the given ket.
+
+    Like for the _cpp attributes, the return type is annotated as the complex variant,
+    although the real variant is returned if real=True.
+    """
+    creator = _backend.BasisAtomCreatorReal() if real else _backend.BasisAtomCreatorComplex()
+    creator.add_ket(ket._cpp)
+    return creator.create(ket.database._cpp)  # type: ignore [return-value]

--- a/src/pairinteraction/basis/basis_pair.py
+++ b/src/pairinteraction/basis/basis_pair.py
@@ -10,13 +10,13 @@ from scipy.sparse import csr_matrix
 from typing_extensions import Self, deprecated
 
 from pairinteraction import _backend
-from pairinteraction.basis.basis_atom import BasisAtom
+from pairinteraction.basis.basis_atom import BasisAtom, get_cpp_basis_atom_from_ket
 from pairinteraction.basis.basis_base import BasisBase
 from pairinteraction.enums import OperatorType, Parity, get_cpp_operator_type, get_cpp_parity
 from pairinteraction.ket import KetPair, KetPairReal, is_ket_atom_tuple
 from pairinteraction.ket.ket_pair import get_ketpairlike_energy, get_ketpairlike_m, is_ket_pair_like
 from pairinteraction.state import StatePair, StatePairReal
-from pairinteraction.state.state_pair import is_state_atom_tuple
+from pairinteraction.state.state_pair import is_state_atom_tuple, is_state_pair_like
 from pairinteraction.units import QuantityArray, QuantityScalar, QuantitySparse
 
 if TYPE_CHECKING:
@@ -364,33 +364,37 @@ class BasisPair(BasisBase[KetPair, StatePair]):
         unit: str | None = None,
     ) -> NDArray | PintArray | csr_matrix | PintSparse:
         operators_cpp = (get_cpp_operator_type(operators[0]), get_cpp_operator_type(operators[1]))
-        matrix_elements_au: NDArray
+        is_real = isinstance(self._cpp, _backend.BasisPairReal)
 
-        # KetPair like
-        if isinstance(other, KetPair):
-            matrix_elements_au = np.array(self._cpp.get_matrix_elements(other._cpp, *operators_cpp, *qs))
-            return QuantityArray.convert_au_to_user(matrix_elements_au, operators, unit)
-        if is_ket_atom_tuple(other):
-            ket_cpp = (other[0]._cpp, other[1]._cpp)
-            matrix_elements_au = np.array(self._cpp.get_matrix_elements(*ket_cpp, *operators_cpp, *qs))
-            return QuantityArray.convert_au_to_user(matrix_elements_au, operators, unit)
+        if is_ket_pair_like(other) or is_state_pair_like(other):
+            # KetPair like
+            if isinstance(other, KetPair):
+                other_cpp = get_cpp_basis_pair_from_atom_bases(other._cpp.get_atomic_states(), real=is_real)
+            elif is_ket_atom_tuple(other):
+                other_cpp = get_cpp_basis_pair_from_atom_bases(
+                    [get_cpp_basis_atom_from_ket(ket, real=is_real) for ket in other], real=is_real
+                )
+            # StatePair like
+            elif isinstance(other, StatePair):
+                other_cpp = other._cpp
+            elif is_state_atom_tuple(other):
+                other_cpp = get_cpp_basis_pair_from_atom_bases([state._cpp for state in other], real=is_real)
+            else:
+                raise TypeError(f"Unknown type: {type(other)=}")
 
-        # StatePair like
-        if isinstance(other, StatePair):
-            matrix_elements_au = self._cpp.get_matrix_elements(other._cpp, *operators_cpp, *qs).toarray().ravel()
-            return QuantityArray.convert_au_to_user(matrix_elements_au, operators, unit)
-        if is_state_atom_tuple(other):
-            state_cpp = (other[0]._cpp, other[1]._cpp)
-            matrix_elements_au = self._cpp.get_matrix_elements(*state_cpp, *operators_cpp, *qs).toarray().ravel()
+            matrix_elements_au = self._cpp.get_matrix_elements(other_cpp, *operators_cpp, *qs).toarray().ravel()
             return QuantityArray.convert_au_to_user(matrix_elements_au, operators, unit)
 
         # BasisPair like
-        if isinstance(other, BasisPair):
-            matrix_elements_sparse_au = self._cpp.get_matrix_elements(other._cpp, *operators_cpp, *qs)
-            return QuantitySparse.convert_au_to_user(matrix_elements_sparse_au, operators, unit)
-        if is_basis_atom_tuple(other):
-            basis_cpp = (other[0]._cpp, other[1]._cpp)
-            matrix_elements_sparse_au = self._cpp.get_matrix_elements(*basis_cpp, *operators_cpp, *qs)
+        if is_basis_pair_like(other):
+            if isinstance(other, BasisPair):
+                other_cpp = other._cpp
+            elif is_basis_atom_tuple(other):
+                other_cpp = get_cpp_basis_pair_from_atom_bases([basis._cpp for basis in other], real=is_real)
+            else:
+                raise TypeError(f"Unknown type: {type(other)=}")
+
+            matrix_elements_sparse_au = self._cpp.get_matrix_elements(other_cpp, *operators_cpp, *qs)
             return QuantitySparse.convert_au_to_user(matrix_elements_sparse_au, operators, unit)
 
         raise TypeError(f"Unknown type: {type(other)=}")
@@ -401,3 +405,24 @@ class BasisPairReal(BasisPair):
     _cpp_creator = _backend.BasisPairCreatorReal  # type: ignore [assignment]
     _ket_class = KetPairReal
     _state_class = StatePairReal
+
+
+def get_cpp_basis_pair_from_atom_bases(
+    basis_atoms_cpp: Sequence[_backend.BasisAtomComplex], *, real: bool
+) -> _backend.BasisPairComplex:
+    """Create a cpp BasisPair object from the product of two cpp BasisAtom objects.
+
+    Like for the _cpp attributes, the cpp objects are annotated as the complex variants,
+    although for BasisPairReal the real variants are used.
+    """
+    if not real:
+        cpp_system_atom_class = _backend.SystemAtomComplex
+        creator = _backend.BasisPairCreatorComplex()
+    else:
+        cpp_system_atom_class = _backend.SystemAtomReal  # type: ignore [assignment]
+        creator = _backend.BasisPairCreatorReal()  # type: ignore [assignment]
+
+    systems = [cpp_system_atom_class(basis_cpp) for basis_cpp in basis_atoms_cpp]
+    for system in systems:
+        creator.add(system)
+    return creator.create()

--- a/src/pairinteraction/state/state_atom.py
+++ b/src/pairinteraction/state/state_atom.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, overload
 
 import numpy as np
 
+from pairinteraction import _backend
 from pairinteraction.enums import get_cpp_operator_type
 from pairinteraction.ket import KetAtom
 from pairinteraction.state.state_base import StateBase
@@ -15,7 +16,6 @@ from pairinteraction.units import QuantityScalar
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-    from pairinteraction import _backend
     from pairinteraction.basis import BasisAtom
     from pairinteraction.database import Database
     from pairinteraction.enums import OperatorType
@@ -220,7 +220,11 @@ class StateAtom(StateBase[KetAtom]):
         cpp_op = get_cpp_operator_type(operator)
 
         if isinstance(other, KetAtom):
-            matrix_elements_au = np.array(self._cpp.get_matrix_elements(other._cpp, cpp_op, q))[0]
+            from pairinteraction.basis.basis_atom import get_cpp_basis_atom_from_ket
+
+            is_real = isinstance(self._cpp, _backend.BasisAtomReal)
+            other_cpp = get_cpp_basis_atom_from_ket(other, real=is_real)
+            matrix_elements_au = self._cpp.get_matrix_elements(other_cpp, cpp_op, q).toarray().ravel()[0]
             return QuantityScalar.convert_au_to_user(matrix_elements_au, operator, unit)
         if isinstance(other, StateAtom):
             matrix_elements_au = self._cpp.get_matrix_elements(other._cpp, cpp_op, q).toarray().ravel()[0]


### PR DESCRIPTION
In C++ only allow get_matrix_elements between basis and basis.
Do handle the special cases like basis-ket overlap only in python