### PR TITLE
Compatibility with fmt 12.2.0

### DIFF
--- a/src/cpp/bindings/LoggerBridge.cpp
+++ b/src/cpp/bindings/LoggerBridge.cpp
@@ -7,6 +7,7 @@
 
 #include <filesystem>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <memory>
 #include <mutex>
 #include <spdlog/sinks/base_sink.h>

--- a/src/cpp/src/database/Database.cpp
+++ b/src/cpp/src/database/Database.cpp
@@ -20,6 +20,7 @@
 #include <cpptrace/cpptrace.hpp>
 #include <duckdb.hpp>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <fstream>
 #include <nlohmann/json.hpp>

--- a/src/cpp/src/database/GitHubDownloader.cpp
+++ b/src/cpp/src/database/GitHubDownloader.cpp
@@ -7,6 +7,7 @@
 
 #include <filesystem>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <fstream>
 #include <future>
 #include <httplib.h>

--- a/src/cpp/src/database/ParquetManager.cpp
+++ b/src/cpp/src/database/ParquetManager.cpp
@@ -11,6 +11,7 @@
 #include <duckdb.hpp>
 #include <filesystem>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <fstream>
 #include <future>
 #include <iomanip>

--- a/src/cpp/src/diagonalize/DiagonalizerFeast.cpp
+++ b/src/cpp/src/diagonalize/DiagonalizerFeast.cpp
@@ -14,6 +14,7 @@
 
 #ifdef WITH_MKL
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <mkl.h>
 #endif // WITH_MKL
 

--- a/src/cpp/src/diagonalize/DiagonalizerLapackeEvd.cpp
+++ b/src/cpp/src/diagonalize/DiagonalizerLapackeEvd.cpp
@@ -10,6 +10,7 @@
 #include <Eigen/Dense>
 #include <cmath>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <spdlog/spdlog.h>
 
 #ifdef WITH_MKL

--- a/src/cpp/src/diagonalize/DiagonalizerLapackeEvr.cpp
+++ b/src/cpp/src/diagonalize/DiagonalizerLapackeEvr.cpp
@@ -10,6 +10,7 @@
 #include <Eigen/Dense>
 #include <cmath>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <limits>
 #include <spdlog/spdlog.h>
 

--- a/src/cpp/src/ket/KetAtom.cpp
+++ b/src/cpp/src/ket/KetAtom.cpp
@@ -10,6 +10,7 @@
 #include <cctype>
 #include <cmath>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <string>
 #include <string_view>
 #include <vector>


### PR DESCRIPTION
From the release notes https://github.com/fmtlib/fmt/releases/tag/12.2.0

> Made the `<fmt/core.h>` header equivalent to `<fmt/base.h>` by default. Code that relied on `<fmt/core.h>` pulling in `<fmt/format.h>` must now either include `<fmt/format.h>` directly or define `FMT_DEPRECATED_HEAVY_CORE` to opt back in.
