### PR TITLE
always link RydState instead of MQDT.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,7 @@ these tutorials enable you to leverage PairInteraction for your projects.
 
 **Utility Tools [External Links]**
 
-- [MQDT.jl] - Learn how to calculate states and matrix elements using multi-channel quantum defect theory with our tool written in Julia.
-
-- [RydState] - Learn how to calculate Rydberg states and matrix elements using single quantum defect theory with our tool written in Python.
+- [RydState] - Learn how to calculate Rydberg states and matrix elements using single-channel and multi-channel quantum defect theory with our tool written in Python.
 
 [Installation]: https://www.pairinteraction.org/pairinteraction/stable/installation/installation.html
 [Tutorials]: https://www.pairinteraction.org/pairinteraction/stable/tutorials/tutorials.html
@@ -167,7 +165,6 @@ these tutorials enable you to leverage PairInteraction for your projects.
 [Overview of PairInteraction's Architecture]: https://www.pairinteraction.org/pairinteraction/stable/contribute/architecture.html
 [Style Guide]: https://www.pairinteraction.org/pairinteraction/stable/contribute/style_guide.html
 [Database Format]: https://www.pairinteraction.org/pairinteraction/stable/contribute/database.html
-[MQDT.jl]: https://github.com/pairinteraction/MQDT.jl
 [RydState]: https://github.com/pairinteraction/rydstate
 
 ## Contributors
@@ -183,7 +180,7 @@ In addition, the following people contributed significantly to the current and/o
 * [Patrick Mischke] - GUI button for fitting c3/c6 coefficients, [archlinux package]
 * [Nicolas Zuber] - Tutorial on Rydberg-ion interaction
 * [Simon Hollerith] - Documentation of the graphical user interface *(not yet in new version)*
-* [Frederic Hummel] - Julia package for multi-channel quantum defect theory, matrix elements
+* [Frederic Hummel] - Multi-channel quantum defect theory, matrix elements
 * [Eduard J. Braun] - Perturbative calculations, installation instructions for Windows
 * [Alicia Keil] - Enhanced and redesigned calculation of Rydberg pair potentials near surfaces
 

--- a/docs/contribute/database.rst
+++ b/docs/contribute/database.rst
@@ -9,18 +9,14 @@ enables the inclusion of new atomic species and even molecules into the software
 code of the software itself.
 
 The currently available databases are hosted on GitHub and are downloaded by PairInteraction when needed. We manage two
-database repositories:
+database repositories, both created with our tool RydState_:
 
-- database-sqdt_: States and matrix elements calculated by single-channel quantum defect theory, utilizing our tool
-  RydState_.
-- database-mqdt_: States and matrix elements calculated by multi-channel quantum defect theory, utilizing our tool
-  MQDT.jl_.
+- database-sqdt_: States and matrix elements calculated by single-channel quantum defect theory.
+- database-mqdt_: States and matrix elements calculated by multi-channel quantum defect theory.
 
 .. _database-mqdt: https://github.com/pairinteraction/database-mqdt/releases
 
 .. _database-sqdt: https://github.com/pairinteraction/database-sqdt/releases
-
-.. _mqdt.jl: https://github.com/pairinteraction/MQDT.jl
 
 .. _rydstate: https://github.com/pairinteraction/rydstate
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,5 +33,4 @@
     :caption: Utility Tools [External Links]
     :hidden:
 
-    MQDT.jl <https://github.com/pairinteraction/MQDT.jl>
     RydState <https://github.com/pairinteraction/rydstate>

--- a/docs/poly.py
+++ b/docs/poly.py
@@ -57,7 +57,7 @@ for t in sorted([t.name for t in _all_tags], reverse=True):
     WANTED_TAGS.append(t)
 WANTED_TAGS = sorted(WANTED_TAGS)
 
-GIT_OBJ = Git(branch_regex="master", tag_regex="|".join([*WANTED_TAGS, LEGACY_VERSION]), buffer_size=1 * 10**9)
+GIT_OBJ = Git(branch_regex="master", tag_regex="|".join([*WANTED_TAGS, LEGACY_VERSION]))
 ALL_TARGETS: list[GitRef] = asyncio.run(GIT_OBJ.retrieve(ROOT_DIR))
 LATEST = max(t for t in WANTED_TAGS)
 logger.info("Found %d target revisions: %s", len(ALL_TARGETS), [t.name for t in ALL_TARGETS])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ docs = [
   "sphinx_autodoc_typehints >= 1.24",
   "sphinx-autobuild >= 2021.3",
   "myst-parser >= 3.0",
-  "sphinx-polyversion >= 1.1",
+  "sphinx-polyversion >= 3",
 ]
 tests = [
   "pytest >= 8.0",


### PR DESCRIPTION
After the v1.3 database-mqdt release, we will archive MQDT.jl in favor of RydState.
Therfore, we should also always refer to RydState in the pairinteraction docs instead of MQDT.jl